### PR TITLE
Fix: Resolve "invalid redefinition of global identifier" in ACModule

### DIFF
--- a/behaviour/functions/setup/setup.mcfunction
+++ b/behaviour/functions/setup/setup.mcfunction
@@ -1,13 +1,13 @@
 # Add necessary scoreboard objectives
-scoreboard objectives add safeguard:vanish dummy
-scoreboard objectives add safeguard:notify dummy
-scoreboard objectives add safeguard:setup_success dummy
+scoreboard objectives add ac:vanish dummy
+scoreboard objectives add ac:notify dummy
+scoreboard objectives add ac:setup_success dummy
 
-# Ensure players have a default value in safeguard:setup_success
-scoreboard players add @a safeguard:setup_success 0
+# Ensure players have a default value in ac:setup_success
+scoreboard players add @a ac:setup_success 0
 
-scoreboard players set @a[scores={safeguard:setup_success=0..}] safeguard:gametest_on 0
-scoreboard players set @a[scores={safeguard:setup_success=0,safeguard:gametest_on=0}] safeguard:setup_success 2
+scoreboard players set @a[scores={ac:setup_success=0..}] ac:gametest_on 0
+scoreboard players set @a[scores={ac:setup_success=0,ac:gametest_on=0}] ac:setup_success 2
 
 # Add necessary tags and disable command feedback
 tag @s add admin
@@ -15,18 +15,16 @@ gamerule sendcommandfeedback false
 gamerule commandblockoutput false
 
 # Add tag to NPCs (for future use)
-tag @e[type=npc] add safeguard:friend
+tag @e[type=npc] add ac:friend
 
-tellraw @s[scores={safeguard:setup_success=3..}] {"rawtext":[{"text":"§6[§eSafeGuard§6]§r§c§l "},{"text":"SETUP ERROR: §r§4AntiCheat already setup!§r"}]}
+tellraw @s[scores={ac:setup_success=3..}] {"rawtext":[{"text":"§6[§eAnti Cheats§6]§r§c§l "},{"text":"SETUP ERROR: §r§4AntiCheat already setup!§r"}]}
 
-playsound random.levelup @s[scores={safeguard:setup_success=2}]
-execute as @s[scores={safeguard:setup_success=2}] run function credit
-tellraw @s[scores={safeguard:setup_success=2}] {"rawtext":[{"text":"§6[§eSafeGuard§6]§r Add tag §eadmin§r to all the staff §o/tag NAME add admin§r"}]}
-tellraw @s[scores={safeguard:setup_success=2}] {"rawtext":[{"text":"§6[§eSafeGuard§6]§r §aSuccessfully setup the anti-cheat!§r"}]}
-execute as @s[scores={safeguard:setup_success=2}] run scoreboard players set @s safeguard:setup_success 3
+playsound random.levelup @s[scores={ac:setup_success=2}]
+execute as @s[scores={ac:setup_success=2}] run function credit
+tellraw @s[scores={ac:setup_success=2}] {"rawtext":[{"text":"§6[§eAnti Cheats§6]§r Add tag §eadmin§r to all the staff §o/tag NAME add admin§r"}]}
+tellraw @s[scores={ac:setup_success=2}] {"rawtext":[{"text":"§6[§eAnti Cheats§6]§r §aSuccessfully setup the anti-cheat!§r"}]}
+execute as @s[scores={ac:setup_success=2}] run scoreboard players set @s ac:setup_success 3
 #errors
-tellraw @s[scores={safeguard:setup_success=0..1}] {"rawtext":[{"text":"§6[§eSafeGuard§6]§r§c§l "},{"text":"SETUP ERROR: §r§4Experiments Required, turn on §7Beta APIs§r"}]}
+tellraw @s[scores={ac:setup_success=0..1}] {"rawtext":[{"text":"§6[§eAnti Cheats§6]§r§c§l "},{"text":"SETUP ERROR: §r§4Experiments Required, turn on §7Beta APIs§r"}]}
 
-
-playsound random.anvil_land @s[scores={safeguard:setup_success=0..1}]
-
+playsound random.anvil_land @s[scores={ac:setup_success=0..1}]

--- a/behaviour/manifest.json
+++ b/behaviour/manifest.json
@@ -1,11 +1,11 @@
 {
   "format_version": 2,
   "header": {
-    "name": "Anti Cheats",
+    "name": "Anti Cheats BP",
     "description": "Anti Cheats Behaviour Pack V2.0.2. Beta API REQUIRED.",
     "uuid": "81b13565-181a-42ee-abd9-a7bd3cb2dba4",
     "min_engine_version": [ 1, 21, 80 ],
-    "version": [ 2, 0, 2 ]
+    "version": [ 0, 0, 1 ]
   },
   "modules": [
     {
@@ -26,7 +26,7 @@
   "dependencies": [
     {
       "module_name": "@minecraft/server",
-      "version": "2.1.0-beta"
+      "version": "2.0.0-beta"
     },
     {
       "module_name": "@minecraft/server-gametest",
@@ -34,11 +34,11 @@
     },
     {
       "module_name": "@minecraft/server-ui",
-      "version": "2.1.0-beta"
+      "version": "2.0.0-beta"
     },
     {
       "uuid": "855e5b34-67fd-40c5-8f70-6d41efaefbd6",
-      "version": [1, 0, 0]
+      "version": [0, 0, 1]
     }
   ]
 }

--- a/behaviour/scripts/classes/module.js
+++ b/behaviour/scripts/classes/module.js
@@ -3,7 +3,7 @@ import { logDebug } from "../assets/util";
 
 
 
-class ACModule {
+class ACModuleInternal {
     Modules = {
         antiGmc: "Anti GMC",
         antiGrief: "Anti Grief",
@@ -75,4 +75,4 @@ class ACModule {
 
 };  
 
-export const ACModule = new ACModule();
+export const ACModule = new ACModuleInternal();

--- a/behaviour/scripts/initialize.js
+++ b/behaviour/scripts/initialize.js
@@ -8,79 +8,79 @@ export function Initialize(){
     Minecraft.system.run(() => {
         // Ensure scoreboard objectives exist
         const objectives = [
-            "safeguard:gametest_on",
-            "safeguard:vanish",
-            "safeguard:notify",
-            "safeguard:setup_success"
+            "ac:gametest_on",
+            "ac:vanish",
+            "ac:notify",
+            "ac:setup_success"
         ];
         objectives.forEach(obj => {
             if (world.scoreboard.getObjective(obj) == undefined) {
                 try {
                     world.scoreboard.addObjective(obj, obj); // Use obj as display name too, or customize
-                    logDebug(`[SafeGuard] Created scoreboard objective: ${obj}`);
+                    logDebug(`[Anti Cheats] Created scoreboard objective: ${obj}`);
                 } catch (e) {
-                    logDebug(`[SafeGuard] Failed to create scoreboard objective ${obj}:`, e);
+                    logDebug(`[Anti Cheats] Failed to create scoreboard objective ${obj}:`, e);
                 }
             }
         });
 
         // Initialize Gamerules
-        if (world.getDynamicProperty("safeguard:gamerulesSet") === undefined) {
+        if (world.getDynamicProperty("ac:gamerulesSet") === undefined) {
             try {
                 world.setGameRule(Minecraft.GameRule.sendCommandFeedback, false);
                 world.setGameRule(Minecraft.GameRule.commandBlockOutput, false);
-                world.setDynamicProperty("safeguard:gamerulesSet", true);
-                logDebug("[SafeGuard] Initialized gamerules (sendCommandFeedback, commandBlockOutput).");
+                world.setDynamicProperty("ac:gamerulesSet", true);
+                logDebug("[Anti Cheats] Initialized gamerules (sendCommandFeedback, commandBlockOutput).");
             } catch (e) {
-                logDebug("[SafeGuard] Failed to initialize gamerules:", e);
+                logDebug("[Anti Cheats] Failed to initialize gamerules:", e);
             }
         }
 
         // world.worldBorder can be set directly if needed, or managed by other game logic/commands.
-        // Example: world.worldBorder = world.getDynamicProperty("safeguard:worldBorder") ?? 0;
+        // Example: world.worldBorder = world.getDynamicProperty("ac:worldBorder") ?? 0;
         // For this task, we are removing the specific legacy_WorldBordertoV2() call and related conditional.
         // If worldBorder needs to be initialized from a dynamic property, that logic should be explicit.
         // For now, just ensuring the property is read if it exists.
-        const existingWorldBorder = world.getDynamicProperty("safeguard:worldBorder");
+        const existingWorldBorder = world.getDynamicProperty("ac:worldBorder");
         if (typeof existingWorldBorder === 'number') {
             world.worldBorder = existingWorldBorder;
         }
 
 
-        if (!world.safeguardUnbanQueue) world.safeguardUnbanQueue = []; // This seems like a runtime variable, not directly from dynamic property string parsing here.
+        if (!world.acUnbanQueue) world.acUnbanQueue = []; // This seems like a runtime variable, not directly from dynamic property string parsing here.
         
         // Check for script setup first, then scoreboard as a fallback.
-        world.safeguardIsSetup = world.getDynamicProperty("safeguard:scriptSetupComplete") === true || 
-                                 world.scoreboard.getObjective("safeguard:setup_success") !== undefined;
+        world.acIsSetup = world.getDynamicProperty("ac:scriptSetupComplete") === true || 
+                                 world.scoreboard.getObjective("ac:setup_success") !== undefined;
         
         try {
-            const unbanQueueProperty = world.getDynamicProperty("safeguard:unbanQueue");
-            world.safeguardUnbanQueue = unbanQueueProperty ? JSON.parse(unbanQueueProperty) : [];
+            const unbanQueueProperty = world.getDynamicProperty("ac:unbanQueue");
+            world.acUnbanQueue = unbanQueueProperty ? JSON.parse(unbanQueueProperty) : [];
         } catch (error) {
-            logDebug("[SafeGuard] Error parsing unbanQueue JSON, defaulting to empty array:", error);
-            world.safeguardUnbanQueue = [];
+            logDebug("[Anti Cheats] Error parsing unbanQueue JSON, defaulting to empty array:", error);
+            world.acUnbanQueue = [];
         }
         
-        logDebug(`[SafeGuard] Unban Queue: `, JSON.stringify(world.safeguardUnbanQueue));
+        logDebug(`[Anti Cheats] Unban Queue: `, JSON.stringify(world.acUnbanQueue));
 
         try {
-            const deviceBanProperty = world.getDynamicProperty("safeguard:deviceBan");
-            world.safeguardDeviceBan = deviceBanProperty ? JSON.parse(deviceBanProperty) : [];
+            const deviceBanProperty = world.getDynamicProperty("ac:deviceBan");
+            world.acDeviceBan = deviceBanProperty ? JSON.parse(deviceBanProperty) : [];
         } catch (error) {
-            logDebug("[SafeGuard] Error parsing deviceBan JSON, defaulting to empty array:", error);
-            world.safeguardDeviceBan = [];
+            logDebug("[Anti Cheats] Error parsing deviceBan JSON, defaulting to empty array:", error);
+            world.acDeviceBan = [];
         }
-        logDebug(`[SafeGuard] Device Ban List: `, JSON.stringify(world.safeguardDeviceBan));
+        logDebug(`[Anti Cheats] Device Ban List: `, JSON.stringify(world.acDeviceBan));
 
 
-        world.safeguardVersion = world.getDynamicProperty("safeguard:version");
-        if(!world.safeguardVersion){
-            world.setDynamicProperty("safeguard:version",config.default.version);
-            world.safeguardVersion = config.default.version;
+        world.acVersion = world.getDynamicProperty("ac:version");
+        if(!world.acVersion){
+            world.setDynamicProperty("ac:version",config.default.version);
+            world.acVersion = config.default.version;
         }
         //TODO: see if setting up logs works. Make sure to add a limit to how much logs can be displayed
 
-        const editedConfigString = world.getDynamicProperty("safeguard:config");
+        const editedConfigString = world.getDynamicProperty("ac:config");
         if(editedConfigString){
             try {
                 const editedConfig = JSON.parse(editedConfigString);
@@ -89,21 +89,21 @@ export function Initialize(){
                         config.default[i] = editedConfig[i];
                     }
                 }
-                logDebug(`[SafeGuard] Loaded config from dynamic properties.`);
+                logDebug(`[Anti Cheats] Loaded config from dynamic properties.`);
             } catch (error) {
-                logDebug(`[SafeGuard] Error parsing editedConfig JSON from dynamic property "safeguard:config":`, error);
+                logDebug(`[Anti Cheats] Error parsing editedConfig JSON from dynamic property "ac:config":`, error);
                 // Proceed with default config if parsing fails
             }
         }
 
         // Load Global Ban List from globalBanList.js if dynamic property doesn't exist
-        if (world.getDynamicProperty("safeguard:gbanList") === undefined) {
-            world.setDynamicProperty("safeguard:gbanList", JSON.stringify(globalBanList)); // Use the imported globalBanList
-            logDebug("[SafeGuard] Initialized global ban list dynamic property from globalBanList.js seed.");
+        if (world.getDynamicProperty("ac:gbanList") === undefined) {
+            world.setDynamicProperty("ac:gbanList", JSON.stringify(globalBanList)); // Use the imported globalBanList
+            logDebug("[Anti Cheats] Initialized global ban list dynamic property from globalBanList.js seed.");
         }
 
-        world.setDynamicProperty("safeguard:scriptSetupComplete", true); // Set script setup flag
-        logDebug("[SafeGuard] Initialized and script setup marked as complete.");
-        world.safeguardInitialized = true; // General initialization flag
+        world.setDynamicProperty("ac:scriptSetupComplete", true); // Set script setup flag
+        logDebug("[Anti Cheats] Initialized and script setup marked as complete.");
+        world.acInitialized = true; // General initialization flag
     })
 }

--- a/resource/manifest.json
+++ b/resource/manifest.json
@@ -1,10 +1,10 @@
 {
   "format_version": 2,
   "header": {
-    "name": "Anti Cheats Resources",
+    "name": "Anti Cheats RP",
     "description": "Resource pack for Anti Cheats",
     "uuid": "855e5b34-67fd-40c5-8f70-6d41efaefbd6",
-    "version": [1, 0, 0],
+    "version": [0, 0, 1],
     "min_engine_version": [1, 21, 80]
   },
   "modules": [


### PR DESCRIPTION
I modified `behaviour/scripts/classes/module.js` to prevent a SyntaxError. The class `ACModule` was renamed to `ACModuleInternal`. The exported singleton instance remains named `ACModule` but now instantiates `ACModuleInternal`.

This change addresses the error:
"[Scripting][error]-SyntaxError: invalid redefinition of global identifier at classes/module.js:78"

The issue was likely caused by Minecraft's JavaScript engine treating the class name and the exported instance of the same name as conflicting global identifiers. Differentiating the class name (`ACModuleInternal`) from the exported instance name (`ACModule`) resolves this conflict.