### PR TITLE
Fix: Resolve SafeguardModule import error and add reciprocal dependency

### DIFF
--- a/behaviour/scripts/classes/player.js
+++ b/behaviour/scripts/classes/player.js
@@ -1,6 +1,6 @@
 import { Player, world, InputPermissionCategory } from "@minecraft/server";
 import { formatMilliseconds, generateBanLog, logDebug, sendMessageToAllAdmins } from "../assets/util";
-import { SafeguardModule } from "./module";
+import { ACModule } from "./module";
 
 Player.prototype.initialClick = 0;
 Player.prototype.finalCps = 0;
@@ -35,12 +35,12 @@ Player.prototype.clearWarnings = function(){
 //set warn
 Player.prototype.setWarning = function(module){
 	try {
-		if (module !== "manual" && !SafeguardModule.getValidModules().includes(module)) {
+		if (module !== "manual" && !ACModule.getValidModules().includes(module)) {
 			logDebug(`[SafeGuard ERROR] Invalid module type for setWarning: ${module}`);
 			throw ReferenceError(`"${module}" isn't a safeguard module.`);
 		}
 		const warnings = this.getWarnings(); // Already has try-catch for parsing
-		const moduleID = module === "manual" ? module : SafeguardModule.getModuleID(module);
+		const moduleID = module === "manual" ? module : ACModule.getModuleID(module);
 
 		if(!warnings[moduleID]) warnings[moduleID] = 1;
 		else warnings[moduleID] += 1;

--- a/resource/manifest.json
+++ b/resource/manifest.json
@@ -14,5 +14,11 @@
       "uuid": "2370fd7e-6d84-4871-b740-fd5e84a7059a",
       "version": [1, 0, 0]
     }
+  ],
+  "dependencies": [
+    {
+      "uuid": "81b13565-181a-42ee-abd9-a7bd3cb2dba4",
+      "version": [0,0,1]
+    }
   ]
 }


### PR DESCRIPTION
This commit addresses two issues:
1. Corrected script error:
    - Changed an import in `behaviour/scripts/classes/player.js` from the non-existent `SafeguardModule` to the correct `ACModule` (exported by `classes/module.js`).
    - Updated usage of this imported module within `player.js`.
    - This fixes the error: "[Scripting][error]-SyntaxError: Could not find export 'SafeguardModule' in module 'classes/module.js'".

2. Added reciprocal pack dependency:
    - Modified `resource/manifest.json` to include a dependency on the Behavior Pack, mirroring the existing dependency from the Behavior Pack to the Resource Pack.