### PR TITLE
Fix: Correct Config Editor UI errors and enhance System Info

### DIFF
--- a/behaviour/scripts/assets/ui.js
+++ b/behaviour/scripts/assets/ui.js
@@ -188,11 +188,11 @@ export function showSystemInformation(player, previousForm) {
 
 	for (const p of allPlayers) {
         if (p.isOwner()) {
-            ownerNames.push(p.name);
+            ownerNames.push(`§c${p.name}§r`); // Add color codes
         } else if (p.hasTag('admin')) { 
-            adminNames.push(p.name);
+            adminNames.push(`§6${p.name}§r`); // Add color codes
         } else {
-            normalPlayerNames.push(p.name);
+            normalPlayerNames.push(`§a${p.name}§r`); // Add color codes
         }
     }
     // Get counts from array lengths
@@ -553,11 +553,11 @@ function configEditorForm(player, previousForm) {
 
 					switch (typeof subValue) {
 						case "boolean":
-							configModuleForm.toggle(`${key} -> ${subKey}\n`, subValue);
+							configModuleForm.toggle(`${key} -> ${subKey}\n`, { defaultValue: subValue });
 							break;
 						case "number":
 						case "string":
-							configModuleForm.textField(`${key} -> ${subKey}\n`, subValue.toString(), subValue.toString());
+							configModuleForm.textField(`${key} -> ${subKey}\n`, subValue.toString(), { defaultValue: subValue.toString() });
 							break;
 					}
 				}
@@ -566,11 +566,11 @@ function configEditorForm(player, previousForm) {
 
 				switch (typeof value) {
 					case "boolean":
-						configModuleForm.toggle(`${key}\n`, value);
+						configModuleForm.toggle(`${key}\n`, { defaultValue: value });
 						break;
 					case "number":
 					case "string":
-							configModuleForm.textField(`${key}\n`, value.toString(), value.toString());
+							configModuleForm.textField(`${key}\n`, value.toString(), { defaultValue: value.toString() });
 						break;
 				}
 			}


### PR DESCRIPTION
This commit addresses UI issues and implements an enhancement:

1.  Fixed `TypeError`s in "Config Editor" (`assets/ui.js`):
    - Ensured that `ModalFormData.toggle` and `ModalFormData.textField` calls within `configEditorForm` correctly use an options object for their `defaultValue` argument (e.g., `{ defaultValue: value }`). This resolves the "Native type conversion failed" errors when opening specific config sections.

2.  Enhanced "System Information" Panel (`assets/ui.js`):
    - Player names in the online lists (Owners, Admins, Normal Players) are now color-coded for better readability (Owners: Red, Admins: Gold, Normal: Green).

3.  Investigation of `CustomCommandRegistry not available` warning:
    - Confirmed that `slash_commands.js` already checks for the availability of the command registration API and logs a warning if it's not present. No code changes made for this, as it indicates an environment/API limitation. Script-based slash commands may not be available if this warning appears.