### PR TITLE
feat: Add separate BP and RP .mcpack releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,47 @@ jobs:
         zip -r "../AC.${{ env.FULL_TAG_NAME }}.mcaddon" ./*
         cd ..
 
-    - name: Upload Release Asset
+    - name: Zip Behavior Pack
+      shell: bash
+      env:
+        FULL_TAG_NAME: ${{ env.FULL_TAG_NAME }}
+      run: |
+        cd staging/"Anti Cheats BP"
+        zip -r "../../AC BP${{ env.FULL_TAG_NAME }}.mcpack" ./*
+        cd ../..
+
+    - name: Upload Behavior Pack Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        FULL_TAG_NAME: ${{ env.FULL_TAG_NAME }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./AC BP${{ env.FULL_TAG_NAME }}.mcpack
+        asset_name: AC BP${{ env.FULL_TAG_NAME }}.mcpack
+        asset_content_type: application/zip
+
+    - name: Zip Resource Pack
+      shell: bash
+      env:
+        FULL_TAG_NAME: ${{ env.FULL_TAG_NAME }}
+      run: |
+        cd staging/"Anti Cheats RP"
+        zip -r "../../AC RP${{ env.FULL_TAG_NAME }}.mcpack" ./*
+        cd ../..
+
+    - name: Upload Resource Pack Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        FULL_TAG_NAME: ${{ env.FULL_TAG_NAME }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./AC RP${{ env.FULL_TAG_NAME }}.mcpack
+        asset_name: AC RP${{ env.FULL_TAG_NAME }}.mcpack
+        asset_content_type: application/zip
+
+    - name: Upload Mcaddon Release Asset
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -29,11 +29,28 @@ This addon for Minecraft Bedrock Edition helps server admins by providing anti-c
 
 ## Installation
 
-1.  **Download:** Get the `.mcaddon` file.
-2.  **Import:** Import the `.mcaddon` into Minecraft (usually by opening the file or through game settings).
-3.  **Apply to World:**
-    *   In a new or existing world, go to "Behavior Packs" and activate "Anti Cheats BP". The "Anti Cheats RP" (Resource Pack) should apply automatically.
-    *   **Enable "Beta APIs"** in your world settings. This is required.
+1.  **Download the Addon Files:**
+    *   **Option 1: `.mcaddon` file (Recommended for most users)**
+        *   Download the `AC.<version>.mcaddon` file (e.g., `AC.v1.2.3.mcaddon`) from the project's releases page. This single file bundles both the Behavior Pack and Resource Pack.
+    *   **Option 2: Separate `.mcpack` files**
+        *   Alternatively, you can download the individual pack files from the project's releases page:
+            *   `AC BPv<version>.mcpack` (Behavior Pack)
+            *   `AC RPv<version>.mcpack` (Resource Pack)
+        *   This method is for users who prefer to install or manage the packs separately.
+
+2.  **Import into Minecraft:**
+    *   **If using the `.mcaddon` file:**
+        *   Open the `.mcaddon` file (e.g., by double-clicking it). Minecraft should launch and import both the Behavior and Resource packs automatically.
+    *   **If using separate `.mcpack` files:**
+        *   Open the `AC BPv<version>.mcpack` file. Minecraft should launch and import the Behavior Pack.
+        *   Then, open the `AC RPv<version>.mcpack` file. Minecraft should launch and import the Resource Pack.
+        *   You may need to do this one at a time.
+
+3.  **Apply to Your World:**
+    *   Create a new world or edit an existing one.
+    *   Go to **Behavior Packs** under "Add-Ons". Find "Anti Cheats BP" in the "Available" packs and activate it.
+    *   Go to **Resource Packs**. "Anti Cheats RP" should be automatically activated in the "Active" packs list. If not, find it in "Available" and activate it.
+    *   **Crucially, enable "Beta APIs"** in your world's "Game" settings (under "Experiments"). This addon requires Beta APIs to function correctly.
 
 ## Configuration
 


### PR DESCRIPTION
Modifies the GitHub Actions release workflow to:
- Create `AC BPv<version>.mcpack` containing the Behavior Pack.
- Create `AC RPv<version>.mcpack` containing the Resource Pack.
- Upload these alongside the existing `AC.v<version>.mcaddon` file as release assets.

Updates README.md to:
- Inform you about the new download options for separate Behavior and Resource packs.
- Provide clear installation instructions for both `.mcaddon` and the individual `.mcpack` files.