### PR TITLE
Fix: Corrected import path for handle.js in panel.js

### DIFF
--- a/Anti Cheats BP/scripts/command/src/panel.js
+++ b/Anti Cheats BP/scripts/command/src/panel.js
@@ -1,4 +1,4 @@
-import { newCommand } from "../../handle.js"; // Path relative to src/
+import { newCommand } from "../handle.js"; // Path relative to src/
 import { showAdminPanel } from "../../../forms/admin_panel.js"; // Path relative to src/
 
 newCommand({


### PR DESCRIPTION
The file `Anti Cheats BP/scripts/command/src/panel.js` was attempting to import `handle.js` using an incorrect relative path (`../../handle.js`). This resulted in a "ReferenceError: Import [handle.js] not found" when `index.js` loaded the command modules.

This commit corrects the import path to `../handle.js`, which accurately points to the location of `handle.js` relative to `panel.js`. This should resolve the script loading error.