### PR TITLE
Fix: Corrected multiple import paths in panel.js

### DIFF
--- a/Anti Cheats BP/scripts/command/src/panel.js
+++ b/Anti Cheats BP/scripts/command/src/panel.js
@@ -1,5 +1,5 @@
-import { newCommand } from "../../handle.js"; // Path relative to src/
-import { showAdminPanel } from "../../../forms/admin_panel.js"; // Path relative to src/
+import { newCommand } from "../handle.js"; // Path relative to src/
+import { showAdminPanel } from "../../forms/admin_panel.js"; // Path relative to src/
 
 newCommand({
     name: "panel",


### PR DESCRIPTION
This commit addresses two import errors in `Anti Cheats BP/scripts/command/src/panel.js`:

1.  The import for `handle.js` was corrected from `../../handle.js` to `../handle.js`.
2.  The import for `admin_panel.js` (specifically `showAdminPanel`) was corrected from `../../../forms/admin_panel.js` to `../../forms/admin_panel.js`.

These changes ensure that `panel.js` correctly locates and imports its dependencies, resolving script loading errors that occurred at startup.