### PR TITLE
Fix: Correct multiple relative import path errors

### DIFF
--- a/Anti Cheats BP/scripts/ac_ui_components.js
+++ b/Anti Cheats BP/scripts/ac_ui_components.js
@@ -6,11 +6,11 @@
 import * as Minecraft from '@minecraft/server';
 import { ActionFormData, MessageFormData, ModalFormData } from '@minecraft/server-ui';
 // Adjusted path: Assuming util.js is in 'Anti Cheats BP/scripts/assets/'
-import { addPlayerToUnbanQueue, copyInv, getPlayerByName, invsee, logDebug, millisecondTime, sendMessageToAllAdmins } from '../assets/util.js'; 
+import { addPlayerToUnbanQueue, copyInv, getPlayerByName, invsee, logDebug, millisecondTime, sendMessageToAllAdmins } from './assets/util.js'; 
 // Adjusted path and class name: Assuming module.js is in 'Anti Cheats BP/scripts/classes/' and uses ACModule
-import { ACModule } from '../classes/module.js'; 
+import { ACModule } from './classes/module.js'; 
 // Adjusted path: Assuming config.js is in 'Anti Cheats BP/scripts/'
-import * as config from "../config.js"; 
+import * as config from "./config.js"; 
 
 const world = Minecraft.world;
 

--- a/Anti Cheats BP/scripts/command/src/panel.js
+++ b/Anti Cheats BP/scripts/command/src/panel.js
@@ -1,5 +1,5 @@
-import { newCommand } from "../../handle.js"; // Path relative to src/
-import { showAdminPanel } from "../../../forms/admin_panel.js"; // Path relative to src/
+import { newCommand } from "../handle.js"; // Path relative to src/
+import { showAdminPanel } from "../../forms/admin_panel.js"; // Path relative to src/
 
 newCommand({
     name: "panel",


### PR DESCRIPTION
This commit resolves several "Import not found" errors caused by incorrect relative paths in your JavaScript files:

1.  In `Anti Cheats BP/scripts/command/src/panel.js`:
    - Corrected import for `handle.js` from `../../handle.js` to `../handle.js`.
    - Corrected import for `admin_panel.js` from `../../../forms/admin_panel.js` to `../../forms/admin_panel.js`.

2.  In `Anti Cheats BP/scripts/ac_ui_components.js`:
    - Corrected import for `util.js` from `../assets/util.js` to `./assets/util.js`.
    - Corrected import for `module.js` from `../classes/module.js` to `./classes/module.js`.
    - Corrected import for `config.js` from `../config.js` to `./config.js`.

These changes ensure that modules correctly locate their dependencies within the `scripts` directory structure, preventing script loading failures at startup.