### PR TITLE
Fix: Resolve multiple JavaScript import errors

### DIFF
--- a/Anti Cheats BP/scripts/ac_ui_components.js
+++ b/Anti Cheats BP/scripts/ac_ui_components.js
@@ -6,11 +6,11 @@
 import * as Minecraft from '@minecraft/server';
 import { ActionFormData, MessageFormData, ModalFormData } from '@minecraft/server-ui';
 // Adjusted path: Assuming util.js is in 'Anti Cheats BP/scripts/assets/'
-import { addPlayerToUnbanQueue, copyInv, getPlayerByName, invsee, logDebug, millisecondTime, sendMessageToAllAdmins } from '../assets/util.js'; 
+import { addPlayerToUnbanQueue, copyInv, getPlayerByName, invsee, logDebug, millisecondTime, sendMessageToAllAdmins } from './assets/util.js'; 
 // Adjusted path and class name: Assuming module.js is in 'Anti Cheats BP/scripts/classes/' and uses ACModule
-import { ACModule } from '../classes/module.js'; 
+import { ACModule } from './classes/module.js'; 
 // Adjusted path: Assuming config.js is in 'Anti Cheats BP/scripts/'
-import * as config from "../config.js"; 
+import * as config from "./config.js"; 
 
 const world = Minecraft.world;
 

--- a/Anti Cheats BP/scripts/classes/player.js
+++ b/Anti Cheats BP/scripts/classes/player.js
@@ -1,5 +1,5 @@
 import { Player, world, InputPermissionCategory } from "@minecraft/server";
-import { formatMilliseconds, generateBanLog, logDebug, sendMessageToAllAdmins, getPlayerByName } from "../assets/util";
+import { formatMilliseconds, generateBanLog, logDebug, sendMessageToAllAdmins, getPlayerByName } from "../assets/util.js";
 import { ACModule } from "./module";
 import { i18n } from '../assets/i18n.js';
 

--- a/Anti Cheats BP/scripts/command/src/panel.js
+++ b/Anti Cheats BP/scripts/command/src/panel.js
@@ -1,5 +1,5 @@
-import { newCommand } from "../../handle.js"; // Path relative to src/
-import { showAdminPanel } from "../../../forms/admin_panel.js"; // Path relative to src/
+import { newCommand } from "../handle.js"; // Path relative to src/
+import { showAdminPanel } from "../../forms/admin_panel.js"; // Path relative to src/
 
 newCommand({
     name: "panel",

--- a/Anti Cheats BP/scripts/initialize.js
+++ b/Anti Cheats BP/scripts/initialize.js
@@ -1,5 +1,5 @@
 import * as Minecraft from '@minecraft/server';
-import { logDebug, scoreboardAction } from './assets/util';
+import { logDebug, scoreboardAction } from './assets/util.js';
 import * as config from './config';
 import { globalBanList } from './assets/global_ban_list.js'; // Added import
 import { i18n } from './assets/i18n.js'; // Import i18n

--- a/Anti Cheats BP/scripts/managers/chat_manager.js
+++ b/Anti Cheats BP/scripts/managers/chat_manager.js
@@ -1,6 +1,6 @@
 import { world } from "@minecraft/server";
 import { CONFIG as config, i18n } from "../config.js";
-import { sendMessageToAdmins, getPlayerRank, 효율 } from "../util.js";
+import { sendMessageToAdmins, getPlayerRank } from "../assets/util.js";
 import { commandHandler } from "../command/handle.js";
 import { inMemoryCommandLogs, MAX_LOG_ENTRIES } from "../systems/periodic_checks.js"; // This will be created later
 

--- a/Anti Cheats BP/scripts/systems/periodic_checks.js
+++ b/Anti Cheats BP/scripts/systems/periodic_checks.js
@@ -1,6 +1,6 @@
 import { world, system, Player, EffectType, EntityDamageCause, GameMode } from "@minecraft/server";
 import { CONFIG as config, i18n } from "../config.js";
-import { sendMessageToAdmins, saveLogToFile, LOG_FILE_PREFIX } from "../util.js";
+import { sendMessageToAdmins, saveLogToFile, LOG_FILE_PREFIX } from "../assets/util.js";
 import { logDebug } from "../assets/util.js"; // Assuming logDebug is in util.js or assets/util.js
 
 // Define the playerInternalStates Map
@@ -42,7 +42,7 @@ export function getPlayerState(playerId) {
     return state;
 }
 import { ACModule } from "../classes/module.js";
-import { Vector3Utils } from "../classes/vector3utils.js";
+import { Vector3utils } from "../classes/vector3.js";
 
 // Log arrays and constants
 export const MAX_LOG_ENTRIES = 100; // Define how many entries to keep in memory


### PR DESCRIPTION
This commit addresses a cascade of import errors that ultimately manifested as "Import [util.js] not found" and later "Import [classes/vector3utils.js] not found".

Key changes include:

1.  In `Anti Cheats BP/scripts/systems/periodic_checks.js`:
    - Corrected import of `Vector3utils` from `../classes/vector3utils.js` (non-existent file) to `../classes/vector3.js` (actual file). This was the primary fix.
    - Corrected import path for `util.js` from `../util.js` to `../assets/util.js`.

2.  In `Anti Cheats BP/scripts/classes/player.js`:
    - Corrected import path for `util.js` from `../assets/util` to `../assets/util.js`.

3.  In `Anti Cheats BP/scripts/initialize.js`:
    - Corrected import path for `util.js` from `./assets/util` to `./assets/util.js`.

4.  In `Anti Cheats BP/scripts/managers/chat_manager.js`:
    - Corrected import path for `util.js` from `../util.js` to `../assets/util.js`.
    - Removed non-existent named import `효율` from `util.js`.

5.  In `Anti Cheats BP/scripts/ac_ui_components.js`:
    - Corrected import path for `util.js` from `../assets/util.js` to `./assets/util.js`.
    - Corrected import path for `module.js` from `../classes/module.js` to `./classes/module.js`.
    - Corrected import path for `config.js` from `../config.js` to `./config.js`.

6.  In `Anti Cheats BP/scripts/command/src/panel.js`:
    - Corrected import path for `handle.js` from `../../handle.js` to `../handle.js`.
    - Corrected import path for `admin_panel.js` from `../../../forms/admin_panel.js` to `../../forms/admin_panel.js`.

All temporary debugging comments related to isolating these errors have been removed, and the above corrections are now integrated.