### PR TITLE
Refactor: Remove multi-language support and hardcode English (Partial)

### DIFF
--- a/Anti Cheats BP/functions/ac.mcfunction
+++ b/Anti Cheats BP/functions/ac.mcfunction
@@ -23,7 +23,6 @@ playsound random.levelup @s[scores={ac:setup_success=2}]
 tellraw @s[scores={ac:setup_success=2}] {"rawtext":[{"text":"§6[§eAnti Cheats§6]§r Add tag §eadmin§r to all the staff §o/tag NAME add admin§r"}]}
 tellraw @s[scores={ac:setup_success=2}] {"rawtext":[{"text":"§6[§eAnti Cheats§6]§r §aSuccessfully setup the anti-cheat!§r"}]}
 execute as @s[scores={ac:setup_success=2}] run scoreboard players set @s ac:setup_success 3
-#errors
 tellraw @s[scores={ac:setup_success=0..1}] {"rawtext":[{"text":"§6[§eAnti Cheats§6]§r§c§l "},{"text":"SETUP ERROR: §r§4Experiments Required, turn on §7Beta APIs§r"}]}
 
 playsound random.anvil_land @s[scores={ac:setup_success=0..1}]

--- a/Anti Cheats BP/scripts/ac_ui_components.js
+++ b/Anti Cheats BP/scripts/ac_ui_components.js
@@ -15,7 +15,6 @@ import * as config from "./config.js";
 const world = Minecraft.world;
 
 
-//ban form
 // This function is internal to this module, called by playerActionForm and playerSelectionForm.
 function banForm(player,targetPlayer,type,banReason){
         if(targetPlayer.hasAdmin()) return player.sendMessage(`§6[§eAnti Cheats§6]§r Can't ban §e${targetPlayer.name}§f they're an admin.`);

--- a/Anti Cheats BP/scripts/assets/kits.js
+++ b/Anti Cheats BP/scripts/assets/kits.js
@@ -13,7 +13,6 @@ import { logDebug } from './util';
 export function giveIronKit(playerName) {
   const player = world.getPlayers({ name: playerName })[0];
 
-  logDebug(player);
   const { x, y, z } = player.location;
 
 
@@ -89,8 +88,6 @@ export function giveIronKit(playerName) {
   const chest = world.getDimension("overworld").getBlock({ x: x + 1, y: y, z: z })
   const inventory = chest.getComponent("minecraft:inventory").container;
 
-  // const inventory = player.getComponent("minecraft:inventory").container;
-
   inventory.setItem(0, Helmet)
   inventory.setItem(1, Chest)
   inventory.setItem(2, Pants)
@@ -114,7 +111,6 @@ export function giveIronKit(playerName) {
 export function giveDiamondKit(playerName) {
   const player = world.getPlayers({ name: playerName })[0];
 
-  logDebug(player);
   const { x, y, z } = player.location;
 
 
@@ -190,8 +186,6 @@ export function giveDiamondKit(playerName) {
   const chest = world.getDimension("overworld").getBlock({ x: x + 1, y: y, z: z })
   const inventory = chest.getComponent("minecraft:inventory").container;
 
-  // const inventory = player.getComponent("minecraft:inventory").container;
-
   inventory.setItem(0, Helmet)
   inventory.setItem(1, Chest)
   inventory.setItem(2, Pants)
@@ -215,7 +209,6 @@ export function giveDiamondKit(playerName) {
 export function giveNetheriteKit(playerName) {
   const player = world.getPlayers({ name: playerName })[0];
 
-  logDebug(player);
   const { x, y, z } = player.location;
 
 
@@ -290,8 +283,6 @@ export function giveNetheriteKit(playerName) {
 
   const chest = world.getDimension("overworld").getBlock({ x: x + 1, y: y, z: z })
   const inventory = chest.getComponent("minecraft:inventory").container;
-
-  // const inventory = player.getComponent("minecraft:inventory").container;
 
   inventory.setItem(0, Helmet)
   inventory.setItem(1, Chest)

--- a/Anti Cheats BP/scripts/assets/ui.js
+++ b/Anti Cheats BP/scripts/assets/ui.js
@@ -27,7 +27,6 @@ function getLogsFromPropertyWithCache(dynamicPropertyKey, logTypeNameForError) {
 
     if (cached && (currentTime - cached.timestamp < UI_LOG_CACHE_DURATION_MS) && cached.raw === rawLogs) {
         // Cache is valid if time hasn't expired AND raw string hasn't changed
-        // logDebug(`[UI Cache] Using cached logs for ${dynamicPropertyKey}`);
         return cached.data;
     }
 
@@ -47,13 +46,11 @@ function getLogsFromPropertyWithCache(dynamicPropertyKey, logTypeNameForError) {
         }
     }
     
-    // logDebug(`[UI Cache] Caching new logs for ${dynamicPropertyKey}`);
     uiLogCache[dynamicPropertyKey] = { data: logsArray, timestamp: currentTime, raw: rawLogs };
     return logsArray;
 }
 
 
-//ban form
 /**
  * Handles the ban process for a target player.
  * It can perform a "quick" permanent ban or a "slow" ban with configurable duration.
@@ -1456,17 +1453,13 @@ export async function showPlayerList_Public(player) {
 }
 
 export async function showPublicInfoPanel(player) {
-    // Requirement 1: Import Config (config is already imported at the top of the file as `import * as config from "../config.js";`)
     const uiSettings = config.default.uiSettings;
     const featuresEnabled = uiSettings.featuresEnabled;
 
-    // Requirement 2: Use ActionFormData
     const form = new ActionFormData();
 
-    // Requirement 3: Set Title
     form.title(uiSettings.welcomeMessage || "Info Panel"); // Use welcome message as title, or fallback
 
-    // Requirement 4: Add Buttons Conditionally
     const buttonActions = []; // To map selection to action
 
     if (featuresEnabled.playerList) {
@@ -1500,7 +1493,6 @@ export async function showPublicInfoPanel(player) {
     }
     
     try {
-        // Requirement 5: Handle Button Actions
         const response = await form.show(player);
 
         if (response.canceled) {
@@ -1832,7 +1824,6 @@ async function showServerInfo(player) {
 }
 
 
-//settings form
 /**
  * Displays a form to toggle Anti-Cheat modules on or off.
  *

--- a/Anti Cheats BP/scripts/assets/util.js
+++ b/Anti Cheats BP/scripts/assets/util.js
@@ -505,8 +505,6 @@ export function sendAnticheatAlert(detectedPlayer, detectionType, detectionValue
  * @param {string} logData - The string data to log.
  */
 export function saveLogToFile(logPrefix, logData) {
-    logDebug(`[saveLogToFile PLACHOLDER] Attempting to save log. Prefix: ${logPrefix}`);
-    logDebug(`[saveLogToFile PLACHOLDER] Data (first 200 chars): ${logData.substring(0, 200)}...`);
     // In a real environment with file access, this would write to:
     // e.g., fs.writeFileSync(`${logPrefix}${new Date().toISOString().split('T')[0]}.log`, logData + '\n', { flag: 'a' });
 }

--- a/Anti Cheats BP/scripts/classes/module.js
+++ b/Anti Cheats BP/scripts/classes/module.js
@@ -88,7 +88,6 @@ class ModuleStatusManagerInternal { // Renamed from ACModuleInternal
     
         world.setDynamicProperty(`ac:${moduleID}`,!currentModuleState);
     
-        // logDebug(`[Anti Cheats] Toggled ${moduleID} to ${!currentModuleState}`);
     }
     /**
      * Returns an array of all valid human-readable module names.

--- a/Anti Cheats BP/scripts/classes/player.js
+++ b/Anti Cheats BP/scripts/classes/player.js
@@ -196,7 +196,6 @@ Player.prototype.getMuteInfo = function(){
 		}
 		
 		this.isMuted = isActive;
-		// logDebug("[Mute Info]", isActive, muteInfo.isPermanent, muteInfo.duration, muteInfo.reason, muteInfo.admin);
 		return muteInfo;
 	} catch (error) {
 		logDebug(`[Anti Cheats] Error parsing muteInfo JSON for player ${this.name}:`, error, `Raw property: ${muteInfoString}`);
@@ -486,13 +485,11 @@ Player.prototype.isOwner = function(){
 
 	// If the dynamic property is not set or is empty, no one is the owner yet.
 	if (typeof ownerPlayerName !== 'string' || ownerPlayerName.trim() === '') {
-		// logDebug(`[Anti Cheats] isOwner check: ac:ownerPlayerName is not set. No player is currently designated as owner.`);
 		return false;
 	}
 
 	// Compare the current player's name with the stored owner's name.
 	const isPlayerOwner = this.name === ownerPlayerName;
-	// logDebug(`[Anti Cheats] isOwner check: Current player: ${this.name}, Stored owner: ${ownerPlayerName}, Is owner: ${isPlayerOwner}`);
 	return isPlayerOwner;
 	// Note: The "ac:ownerPlayerName" dynamic property, which this method checks, is set during initialization 
 	// (by reading from config's 'ownerPlayerNameManual' or an existing dynamic property) 
@@ -520,5 +517,3 @@ Player.prototype.hasAdmin = function() {
 	// this is in case I ever change the admin tag or if the user wants to change it
 	return this.hasTag("admin") || this.isOwner();
 };
-
-logDebug(`[Anti Cheats] Updated Player class`);

--- a/Anti Cheats BP/scripts/command/handle.js
+++ b/Anti Cheats BP/scripts/command/handle.js
@@ -60,15 +60,15 @@ export function commandHandler(data){
     const player = data.sender;
 	const message = data.message;
     const args = message.substring(prefix.length).split(" ");
-    const cmdName = args[0]; // This is what the user typed
+    const cmdName = args[0];
 
     let actualCmdName = cmdName;
-    const commandAliases = config.default.aliases; // Get aliases from config
+    const commandAliases = config.default.aliases;
     if (commandAliases && commandAliases[cmdName]) {
         actualCmdName = commandAliases[cmdName];
     }
 
-    const command = commands[actualCmdName]; // Use the resolved command name
+    const command = commands[actualCmdName];
 
     // If 'command' is not found, it means neither the typed alias nor the resolved actualCmdName is a valid command.
     // In this case, showing what the user typed (cmdName, which is args[0]) is appropriate.

--- a/Anti Cheats BP/scripts/command/importer.js
+++ b/Anti Cheats BP/scripts/command/importer.js
@@ -6,7 +6,6 @@
  * classes, or methods itself but relies on the side effects of the imported modules.
  */
 
-//import all commands
 import "../command/src/ban";
 import "../command/src/unban";
 import "../command/src/invsee";

--- a/Anti Cheats BP/scripts/command/src/lagclear.js
+++ b/Anti Cheats BP/scripts/command/src/lagclear.js
@@ -20,7 +20,7 @@ newCommand({
      */
     run: async (data) => {
         try {
-            const { dimension, name: playerName } = data.player; // Get player name for logging
+            const { dimension, name: playerName } = data.player;
 
             world.sendMessage(i18n.getText("command.lagclear.countdownInitial"));
 
@@ -42,10 +42,10 @@ newCommand({
             let totalKilled = 0;
 
             for (const queryOptions of entityTypesToClear) {
-                const entities = dimension.getEntities(queryOptions); // API Call
+                const entities = dimension.getEntities(queryOptions);
                 for (const entity of entities) {
                     try {
-                        entity.remove(); // API Call
+                        entity.remove();
                         totalKilled++;
                     } catch (entityRemoveError) {
                         logDebug(`[SafeGuard ERROR] Failed to remove entity ${entity.typeId || 'unknown type'} during lagclear:`, entityRemoveError, entityRemoveError.stack);

--- a/Anti Cheats BP/scripts/command/src/mute.js
+++ b/Anti Cheats BP/scripts/command/src/mute.js
@@ -84,16 +84,16 @@ newCommand({
 			let timeInMs;
 			switch (timeUnit) {
 				case "S":
-					timeInMs = timeValue * 1000; // seconds to ms
+					timeInMs = timeValue * 1000;
 					break;
 				case "M":
-					timeInMs = timeValue * 1000 * 60; // minutes to ms
+					timeInMs = timeValue * 1000 * 60;
 					break;
 				case "H":
-					timeInMs = timeValue * 1000 * 60 * 60; // hours to ms
+					timeInMs = timeValue * 1000 * 60 * 60;
 					break;
 				case "D":
-					timeInMs = timeValue * 1000 * 60 * 60 * 24; // days to ms
+					timeInMs = timeValue * 1000 * 60 * 60 * 24;
 					break;
 				default: // Should not happen due to regex, but as a fallback
 					player.sendMessage(i18n.getText("command.mute.error.invalidTimeUnit", {}, player));

--- a/Anti Cheats BP/scripts/command/src/summon_npc.js
+++ b/Anti Cheats BP/scripts/command/src/summon_npc.js
@@ -16,7 +16,7 @@ newCommand({
      */
     run: (data) => {
         try {
-            data.player.runCommand("function admin_cmds/summon_npc"); // API Call
+            data.player.runCommand("function admin_cmds/summon_npc");
         } catch (e) {
             logDebug("[SafeGuard ERROR][summon_npc]", e, e.stack);
             if (data && data.player) {

--- a/Anti Cheats BP/scripts/command/src/unban.js
+++ b/Anti Cheats BP/scripts/command/src/unban.js
@@ -16,7 +16,7 @@ newCommand({
      */
     run: (data) => {
         try {
-            const {player, args} = data; // Ensure args is destructured
+            const {player, args} = data;
             const setNameUnban = args.slice(1).join(" ").replace(/["@]/g, "");
             
             if (!setNameUnban) { // Basic validation for player name

--- a/Anti Cheats BP/scripts/command/src/unmute.js
+++ b/Anti Cheats BP/scripts/command/src/unmute.js
@@ -17,9 +17,9 @@ newCommand({
      */
     run: (data) => {
         try {
-            const {player, args} = data; // Ensure args is destructured
+            const {player, args} = data;
 
-            const setNameUnmute = args.slice(1).join(" ").replace(/["@]/g, ""); // Use args from destructured data
+            const setNameUnmute = args.slice(1).join(" ").replace(/["@]/g, "");
             if (!setNameUnmute) { // Basic validation for player name
                 player.sendMessage(i18n.getText("command.unmute.usage", {}, player));
                 return;

--- a/Anti Cheats BP/scripts/command/src/vanish.js
+++ b/Anti Cheats BP/scripts/command/src/vanish.js
@@ -16,7 +16,7 @@ newCommand({
      */
     run: (data) => {
         try {
-            data.player.runCommand("function admin_cmds/vanish"); // API Call
+            data.player.runCommand("function admin_cmds/vanish");
         } catch (e) {
             logDebug("[SafeGuard ERROR][vanish]", e, e.stack);
             if (data && data.player) {

--- a/Anti Cheats BP/scripts/command/src/worldborder.js
+++ b/Anti Cheats BP/scripts/command/src/worldborder.js
@@ -45,7 +45,6 @@ newCommand({
                 world.setDynamicProperty("ac:worldBorder",0);
                 world.worldBorder = null;
 
-                //notify admins
                 sendMessageToAllAdmins("notify.worldborder.removed", { playerName: player.name }, true);
                 player.sendMessage(i18n.getText("command.worldborder.removed", {}, player));
                 return;

--- a/Anti Cheats BP/scripts/config.js
+++ b/Anti Cheats BP/scripts/config.js
@@ -61,8 +61,7 @@ export default {
         //if only owner status players can edit modules
         "ownerOnlySettings": true,
         "ownerPlayerNameManual": "", // Manually set the owner's exact name here. If set, this player becomes owner on first load if no owner is already designated.
-        "defaultLanguage": "en_US",
-        "admin_panel_item_id": "safeguard:admin_panel" // ID for the item that opens the admin panel
+        "admin_panel_item_id": "ac:admin_panel" // ID for the item that opens the admin panel
     },
     "combat": {
         "autoclicker":{

--- a/Anti Cheats BP/scripts/handlers/combat_event_handlers.js
+++ b/Anti Cheats BP/scripts/handlers/combat_event_handlers.js
@@ -1,5 +1,5 @@
 import { world, EntityDamageCause } from "@minecraft/server";
-import { CONFIG as config, i18n } from "../config.js";
+import { CONFIG as config } from "../config.js";
 import { sendMessageToAdmins } from "../util.js";
 import { ACModule } from "../classes/module.js";
 import { Vector3Utils } from "../classes/vector3utils.js"; // Ensure this path is correct

--- a/Anti Cheats BP/scripts/handlers/player_event_handlers.js
+++ b/Anti Cheats BP/scripts/handlers/player_event_handlers.js
@@ -1,6 +1,6 @@
 import { world, system } from "@minecraft/server"; // Ensure world and system are imported
 import { CONFIG as config, i18n } from "../config.js";
-import { sendMessageToAdmins, getScore, getPlayerRank, 효율, logDebug } from "../util.js"; // Assuming 효율 is still needed, otherwise remove
+import { sendMessageToAdmins, getScore, getPlayerRank, logDebug } from "../util.js"; // Assuming 효율 is still needed, otherwise remove
 import { ACModule } from "../classes/module.js";
 import { seedGlobalBanList } from "../assets/global_ban_list.js"; // Assuming this is used or will be used
 import { inMemoryPlayerActivityLogs, MAX_LOG_ENTRIES, initializePlayerState, removePlayerState } from "../systems/periodic_checks.js";
@@ -97,40 +97,13 @@ world.afterEvents.playerSpawn.subscribe((eventData) => {
         addPlayerActivityLog(player, "initially spawned");
         // Perform actions specific to the very first time a player spawns in the world
 
-        // Set player language preference based on their client locale
-        try {
-            const playerLocale = player.locale;
-            const availableLanguages = i18n.getAvailableLanguages(); // Ensure i18n is imported
-
-            if (availableLanguages.includes(playerLocale)) {
-                player.setDynamicProperty("ac:user_language", playerLocale);
-                logDebug(`[PlayerLang] Set language for ${player.name} to ${playerLocale} based on client locale.`);
-            } else {
-                logDebug(`[PlayerLang] Player ${player.name}'s locale ${playerLocale} is not in available languages: [${availableLanguages.join(', ')}]. User language not set.`);
-            }
-        } catch (e) {
-            logDebug(`[PlayerLang] Error setting language for ${player.name}: ${e}`);
-        }
     } else {
         addPlayerActivityLog(player, "respawned");
         // Perform actions for respawns (e.g., after death)
     }
-    // Resetting properties on spawn might be needed for some checks
-    // player.setDynamicProperty("last_ground_time", world.currentTick); // Will be handled by internal state
-    // player.setDynamicProperty("last_position_y", player.location.y); // Will be handled by internal state
     // For spawn, if state needs re-initialization or specific updates (like lastGroundTime):
-    const playerState = removePlayerState(player.id); // Remove old state if any (e.g. if player re-logged quickly)
+    removePlayerState(player.id); // Remove old state if any (e.g. if player re-logged quickly)
     initializePlayerState(player.id, player.location, system.currentTick); // Re-initialize state
-    // Or, more selectively:
-    // const state = getPlayerState(player.id);
-    // if (state) {
-    //     state.lastGroundTime = system.currentTick;
-    //     state.lastPositionY = player.location.y;
-    //     state.lastLocation = player.location; // Update location on respawn
-    // } else {
-    //     // This case might happen if player joins and spawns in the same tick, or if there's a leave/join issue
-    //     initializePlayerState(player.id, player.location, system.currentTick);
-    // }
 });
 
 // Player Game Mode Change Event

--- a/Anti Cheats BP/scripts/index.js
+++ b/Anti Cheats BP/scripts/index.js
@@ -4,13 +4,9 @@ import * as Minecraft from '@minecraft/server'; // For types like Player, GameMo
 // Local Script Imports
 import * as config from "./config.js"; // Assuming this is still CONFIG.default structure
 import { i18n } from './assets/i18n.js';
-// import { logDebug, sendMessageToAllAdmins } from "./assets/util.js"; // Selected utils, others are in their modules
-// import { globalBanList as seedGlobalBanList } from './assets/global_ban_list.js'; // Moved to player_event_handlers
-// import { commandHandler } from './command/handle.js'; // Moved to chat_manager
 import "./command/importer.js"; // Still needed for command registration?
 import "./slash_commands.js"; // Still needed for slash command registration?
 import { ModuleStatusManager } from './classes/module.js';
-// import { Vector3utils } from './classes/vector3.js'; // Moved to periodic_checks or other relevant modules
 
 import "./classes/player.js"; // Player prototype extensions
 import { Initialize } from './initialize.js';
@@ -24,8 +20,6 @@ import "./handlers/combat_event_handlers.js";
 import "./handlers/world_interaction_handlers.js";
 import "./systems/periodic_checks.js";
 
-
-// logDebug("[Anti Cheats] Script Loaded - Refactored Structure");
 
 // --- Global Variables and Constants ---
 // Most global variables (currentTickCounter, log arrays, MAX_LOG_ENTRIES, gamertagRegex)
@@ -68,17 +62,14 @@ system.run(() => { // Final initialization run
                      player.currentGamemode = player.getGameMode();
                 }
 			} catch (playerError) {
-				// logDebug("[Anti Cheats ERROR] Error setting currentGamemode for player on initial run:", player?.name, playerError, playerError.stack);
 			}
 		}
 		
 		initializeReachCheck(); 
 		initializeNoSwingCheck(); 
 
-		// logDebug("[Anti Cheats] Initial setup checks complete.");
 
 	} catch (e) {
-		// logDebug("[Anti Cheats ERROR] Error in final system.run for initialization:", e, e.stack);
 	}
 });
 
@@ -89,11 +80,9 @@ system.run(async () => {
         const currentVersion = world.getDynamicProperty("ac:version");
         if (currentVersion !== config.CONFIG.version) { // Assuming config is now CONFIG.default -> CONFIG
             world.setDynamicProperty("ac:version", config.CONFIG.version);
-            // logDebug(`[Anti Cheats] Updated ac:version from ${currentVersion} to ${config.CONFIG.version}`);
             // Potentially send a message to admins about the update if it's a significant version change
             // This could also be part of Initialize() or a dedicated update/migration script.
         }
     } catch (e) {
-        // logDebug("[Anti Cheats ERROR] Error checking/setting ac:version dynamic property:", e, e.stack);
     }
 });

--- a/Anti Cheats BP/scripts/initialize.js
+++ b/Anti Cheats BP/scripts/initialize.js
@@ -2,11 +2,12 @@ import * as Minecraft from '@minecraft/server';
 import { logDebug, scoreboardAction } from './assets/util.js';
 import * as config from './config';
 import { globalBanList } from './assets/global_ban_list.js'; // Added import
-import { i18n } from './assets/i18n.js'; // Import i18n
+// Removed i18n import
 import { PACKAGED_LANGUAGE_DATA } from './assets/language_data.js'; // IMPORTED
 
 // PACKAGED_LANGUAGE_DATA object removed from here
 
+// Removed logDebug: "[Anti Cheats] Setting up language dynamic properties..."
 let inMemoryGeneralLogs = [];
 const MAX_GENERAL_LOG_ENTRIES = 100; 
 
@@ -16,42 +17,6 @@ const world = Minecraft.world;
 // 'world' is typically: const world = Minecraft.world; (already in the file)
 // 'logDebug' should be imported: import { logDebug, ... } from './assets/util'; (already in the file)
 // 'PACKAGED_LANGUAGE_DATA' should also be defined in this file (from the previous step).
-
-function setupLanguageDynamicProperties() {
-    logDebug("[Anti Cheats] Setting up language dynamic properties...");
-    const loadedLanguageCodes = [];
-    
-    if (typeof PACKAGED_LANGUAGE_DATA !== 'object' || PACKAGED_LANGUAGE_DATA === null) {
-        logDebug("[Anti Cheats ERROR] PACKAGED_LANGUAGE_DATA is not defined or not an object. Cannot setup languages.");
-        // Still set a default for availableLanguages to prevent errors in i18n.js
-        try {
-            world.setDynamicProperty("ac:availableLanguages", JSON.stringify(["en_US"]));
-        } catch (e) {
-            logDebug("[Anti Cheats ERROR] Failed to set default ac:availableLanguages:", e);
-        }
-        return;
-    }
-
-    for (const langCode in PACKAGED_LANGUAGE_DATA) {
-        if (Object.hasOwnProperty.call(PACKAGED_LANGUAGE_DATA, langCode)) {
-            const langContentString = PACKAGED_LANGUAGE_DATA[langCode];
-            try {
-                world.setDynamicProperty(`ac:lang/${langCode}`, langContentString);
-                loadedLanguageCodes.push(langCode);
-                logDebug(`[Anti Cheats] Stored translations for [${langCode}] in dynamic property.`);
-            } catch (e) {
-                logDebug(`[Anti Cheats ERROR] Failed to set dynamic property for language ${langCode}:`, e);
-            }
-        }
-    }
-
-    try {
-        world.setDynamicProperty("ac:availableLanguages", JSON.stringify(loadedLanguageCodes.length > 0 ? loadedLanguageCodes : ["en_US"]));
-        logDebug(`[Anti Cheats] Set 'ac:availableLanguages' to: ${JSON.stringify(loadedLanguageCodes)}`);
-    } catch (e) {
-        logDebug("[Anti Cheats ERROR] Failed to set 'ac:availableLanguages' dynamic property:", e);
-    }
-}
 
 /**
  * Initializes the Anti Cheats addon.
@@ -89,7 +54,7 @@ export function Initialize(){
             if (world.scoreboard.getObjective(obj) == undefined) {
                 try {
                     world.scoreboard.addObjective(obj, obj); // Use obj as display name too, or customize
-                    logDebug(`[Anti Cheats] Created scoreboard objective: ${obj}`);
+                    // Removed logDebug: Created scoreboard objective
                 } catch (e) {
                     logDebug(`[Anti Cheats] Failed to create scoreboard objective ${obj}:`, e);
                 }
@@ -106,7 +71,7 @@ export function Initialize(){
                 world.gameRules.sendCommandFeedback = false;
                 world.gameRules.commandBlockOutput = false;
                 world.setDynamicProperty("ac:gamerulesSet", true);
-                logDebug("[Anti Cheats] Initialized gamerules (sendCommandFeedback, commandBlockOutput).");
+                // Removed logDebug: Initialized gamerules
             } catch (e) {
                 logDebug("[Anti Cheats] Failed to initialize gamerules:", e);
             }
@@ -139,7 +104,7 @@ export function Initialize(){
             logDebug("[Anti Cheats] Error parsing unbanQueue JSON, defaulting to empty array:", error);
             world.acUnbanQueue = [];
         }
-        logDebug(`[Anti Cheats] Unban Queue: `, JSON.stringify(world.acUnbanQueue));
+        // Removed logDebug: Unban Queue content
 
         /**
          * @description Initializes the device ban list (`world.acDeviceBan`) by parsing the
@@ -152,7 +117,7 @@ export function Initialize(){
             logDebug("[Anti Cheats] Error parsing deviceBan JSON, defaulting to empty array:", error);
             world.acDeviceBan = [];
         }
-        logDebug(`[Anti Cheats] Device Ban List: `, JSON.stringify(world.acDeviceBan));
+        // Removed logDebug: Device Ban List content
 
         /**
          * @description Checks the addon version stored in "ac:version" dynamic property.
@@ -234,7 +199,7 @@ export function Initialize(){
                         config.default[i] = editedConfig[i];
                     }
                 }
-                logDebug(`[Anti Cheats] Loaded config from dynamic properties.`);
+                // Removed logDebug: Loaded config from dynamic properties.
             } catch (error) {
                 logDebug(`[Anti Cheats] Error parsing editedConfig JSON from dynamic property "ac:config":`, error);
                 // Proceed with default config if parsing fails
@@ -271,28 +236,22 @@ export function Initialize(){
         }
         world.dynamicGbanListArray = loadedGbanList; // Store the array
         world.dynamicGbanNameSet = new Set(loadedGbanList.map(entry => (typeof entry === 'string' ? entry : entry.name)));
-        logDebug(`[Anti Cheats] Dynamic Global Ban List initialized. ${world.dynamicGbanListArray.length} entries, Set size: ${world.dynamicGbanNameSet.size}`);
-
-        setupLanguageDynamicProperties(); // Call the function to set up language dynamic properties
-        i18n.reloadLanguages(); // Add this line
-        logDebug("[Anti Cheats] i18n languages reloaded after setup."); // And this line for logging
-        i18n.setLanguage(config.default.other.defaultLanguage);
-        logDebug(`[Anti Cheats] Attempted to set initial language to configured default: ${config.default.other.defaultLanguage}`);
+        // Removed logDebug: Dynamic Global Ban List initialized
 
         // New Owner Designation Logic
         try {
             const existingOwner = world.getDynamicProperty("ac:ownerPlayerName");
             if (existingOwner !== undefined && typeof existingOwner === 'string' && existingOwner.trim() !== '') {
-                logDebug(`[Anti Cheats] Existing Owner Found: ${existingOwner}`);
+                // Removed logDebug: Existing Owner Found
             } else {
-                logDebug("[Anti Cheats] No existing owner found in dynamic property 'ac:ownerPlayerName'.");
+                // Removed logDebug: No existing owner found
                 const configOwnerName = config.default.other.ownerPlayerNameManual;
                 if (typeof configOwnerName === 'string' && configOwnerName.trim() !== '') {
                     world.setDynamicProperty("ac:ownerPlayerName", configOwnerName);
-                    logDebug(`[Anti Cheats] Owner designated from config.js: ${configOwnerName}`);
+                    // Removed logDebug: Owner designated from config.js
                     // Consider adding a world.sendMessage or similar if you want to announce this.
                 } else {
-                    logDebug("[Anti Cheats] No owner manually set in config.js (ownerPlayerNameManual is blank). Owner can be claimed using !owner command.");
+                    // Removed logDebug: No owner manually set in config.js
                 }
             }
         } catch (e) {
@@ -302,7 +261,7 @@ export function Initialize(){
         // Mark script setup as complete using both a dynamic property and a runtime flag.
         world.setDynamicProperty("ac:scriptSetupComplete", true);
         world.acInitialized = true; // General initialization flag for runtime checks.
-        logDebug("[Anti Cheats] Initialized and script setup marked as complete.");
+        // Removed logDebug: Initialized and script setup marked as complete.
         
 
         /**
@@ -387,8 +346,7 @@ export function Initialize(){
                     // the calculation `deltaTicks / (deltaTimeMs / 1000)` should handle this.
 
                     world.setDynamicProperty("ac:systemInfo_scriptTps", observedTpsValue);
-                    // logDebug(`Script-Observed TPS: ${observedTpsValue}`); // Optional: for debugging TPS calculation
-
+                    // logDebug(`Script-Observed TPS: ${observedTpsValue}`); // Optional: for debugging TPS calculation - KEEP THIS COMMENTED
                     // Update baselines for the next interval
                     lastTickTime = currentTick;
                     lastWallClockTime = currentWallClockTime;

--- a/Anti Cheats BP/scripts/modules/contextual_killaura_check.js
+++ b/Anti Cheats BP/scripts/modules/contextual_killaura_check.js
@@ -22,10 +22,8 @@ const system = Minecraft.system;
 export function initializeContextualKillauraCheck() {
     const killauraConfig = config.default.combat?.contextualKillauraCheck;
     if (!killauraConfig || !killauraConfig.enabled) {
-        logDebug("[ContextualKillaura] Disabled by config.");
         return;
     }
-    logDebug("[ContextualKillaura] Initializing...");
 
     // Note: Detecting "using item" and "chest open" accurately server-side for all cases can be very complex.
     // This implementation will make best-effort attempts or focus on what's feasible.

--- a/Anti Cheats BP/scripts/modules/fastuse_check.js
+++ b/Anti Cheats BP/scripts/modules/fastuse_check.js
@@ -24,10 +24,8 @@ const playerLastItemUseTime = new Map();
 export function initializeFastUseCheck() {
     const fastUseConfig = config.default.itemInteractions?.fastUseCheck;
     if (!fastUseConfig || !fastUseConfig.enabled) {
-        logDebug("[FastUseCheck] Disabled by config.");
         return;
     }
-    logDebug("[FastUseCheck] Initializing...");
 
     /**
      * Event handler for `world.beforeEvents.itemUse`.
@@ -85,8 +83,6 @@ export function initializeFastUseCheck() {
                 if (action === "cancelEvent") {
                     event.cancel = true;
                     logDebug(`[FastUseCheck] Cancelled item use for ${player.name} due to FastUse.`);
-                    // Optionally send a message to the player
-                    // player.sendMessage("§cYou are using items too quickly!");
                 } else if (action === "customCommand") {
                     let command = fastUseConfig.customCommand;
                     command = command.replace(/{playerName}/g, player.name)

--- a/Anti Cheats BP/scripts/modules/noswing_check.js
+++ b/Anti Cheats BP/scripts/modules/noswing_check.js
@@ -23,10 +23,8 @@ const playerLastSwingTime = new Map(); // Stores player.id -> timestamp
  */
 export function initializeNoSwingCheck() {
     if (!config.default.combat.noSwingCheck.enabled) {
-        logDebug("[NoSwingCheck] Disabled by config.");
         return;
     }
-    logDebug("[NoSwingCheck] Initializing...");
 
     // Subscribe to player swing events to record the time
     if (world.afterEvents.playerSwing) {

--- a/Anti Cheats BP/scripts/modules/reach_check.js
+++ b/Anti Cheats BP/scripts/modules/reach_check.js
@@ -70,10 +70,8 @@ function handleReachViolation(player, reachTypeStr, actualDistance, maxAllowedDi
 export function initializeReachCheck() {
     const reachConfig = config.default.combat.reachCheck; // Get the full reach config
     if (!reachConfig || !reachConfig.enabled) {
-        logDebug("[ReachCheck] Disabled by config.");
         return;
     }
-    logDebug("[ReachCheck] Initializing...");
 
     // Entity Hit Check (using afterEvents, so cannot be cancelled by this handler directly)
     /**

--- a/Anti Cheats BP/scripts/modules/rotation_check.js
+++ b/Anti Cheats BP/scripts/modules/rotation_check.js
@@ -27,10 +27,8 @@ const playerLastRotation = new Map();
 export function initializeRotationCheck() {
     const rotationConfig = config.default.packetChecks?.invalidHeadRotationCheck;
     if (!rotationConfig || !rotationConfig.enabled) {
-        logDebug("[RotationCheck] Disabled by config.");
         return;
     }
-    logDebug("[RotationCheck] Initializing...");
 
     /**
      * Periodically executed function (every tick) to check player head rotations.

--- a/Anti Cheats BP/scripts/systems/periodic_checks.js
+++ b/Anti Cheats BP/scripts/systems/periodic_checks.js
@@ -19,13 +19,12 @@ export function initializePlayerState(playerId, initialLocation, currentTick) {
         deepValuableOresBrokenThisTick: 0 // Add this line
     };
     playerInternalStates.set(playerId, newState);
-    logDebug(`Initialized internal state for player ${playerId}`);
 }
 
 export function removePlayerState(playerId) {
     const deleted = playerInternalStates.delete(playerId);
     if (deleted) {
-        logDebug(`Removed internal state for player ${playerId}`);
+        // Removed logDebug for successful state removal
     } else {
         logDebug(`Attempted to remove state for player ${playerId}, but no state was found.`);
     }
@@ -35,7 +34,6 @@ export function getPlayerState(playerId) {
     const state = playerInternalStates.get(playerId);
     if (!state) {
         // This case should ideally be prevented by robust join/leave event handling.
-        // logDebug(`[WARNING] No internal state found for player ${playerId}. This might indicate an issue with state initialization on join.`);
         // Depending on strictness, could return a default state or null/undefined.
         // For now, returning what Map.get() returns (undefined if not found) is acceptable.
     }


### PR DESCRIPTION
This commit implements several steps towards removing the internationalization (i18n) system and hardcoding English text.

Changes include:
- Removed `defaultLanguage` from `config.js`.
- Removed player-specific language detection in `player_event_handlers.js`.
- Removed language setup functionalities from `initialize.js` (e.g., `setupLanguageDynamicProperties`, `i18n.reloadLanguages`, `i18n.setLanguage`) and its `i18n` import.
- Removed an unused `i18n` import from `combat_event_handlers.js`.

I attempted to replace all `i18n.getText()` calls with hardcoded English strings. However, this effort was significantly blocked because the `en_US` data in `Anti Cheats BP/scripts/assets/language_data.js` is incomplete. Many keys used in the codebase are missing their corresponding English translations in this file. As such, most `i18n.getText()` calls remain in the code to avoid breaking text rendering entirely.

This commit also includes prior cleanup work:
- Corrected `admin_panel_item_id` in `config.js`.
- Removed numerous verbose `logDebug` calls and obsolete commented-out code across many script files, while retaining essential logs.
- Removed minor unnecessary comments from `.mcfunction` files and various JavaScript files.