### PR TITLE
Feat: Update command aliases and remove internationalization

### DIFF
--- a/Anti Cheats BP/scripts/assets/i18n.js
+++ b/Anti Cheats BP/scripts/assets/i18n.js
@@ -1,9 +1,7 @@
-import { world } from '@minecraft/server';
-import { logDebug } from './util.js';
-import { CONFIG as config } from '../config.js'; // Added import
+// import { world } from '@minecraft/server'; // No longer needed as dynamic properties for lang are removed
+// import { logDebug } from './util.js'; // No longer needed as language loading is removed
 
-// Removed: translations, initialized, serverDefaultLanguageCode, currentlyLoadedLangInTranslations, englishTranslations
-
+// fallbackTranslations contains all the English strings used by the Anti Cheats system.
 const fallbackTranslations = {
     "system.error.criticalLoadFailed": "Anti Cheats Critical Error: Core language file (en_US) not found in dynamic properties. Some features may be disabled or messages may be missing. Please ensure the addon is set up correctly.",
     "system.setup.prompt": "Anti Cheats: Setup might be required. If you are an admin, please check the configuration and run initial setup commands if necessary.",
@@ -138,38 +136,32 @@ const fallbackTranslations = {
     "system.beta_features_enabled": "Note: Beta features are enabled. Some functionalities might be unstable."
 };
 
-// Removed: loadEnglishBase function
-// Removed: loadLanguageFile function
-// Removed: Initial load sequence (calls to loadEnglishBase and loadLanguageFile)
-
 export const i18n = {
     /**
      * Retrieves a translated string by its key and replaces placeholders.
-     * @param {string} key - The translation key (e.g., "chat.message.welcome").
+     * Uses a predefined fallback object for English strings.
+     * @param {string} key - The translation key (e.g., "command.ban.success").
      * @param {object} [placeholders={}] - An object mapping placeholder names to their values.
      *                                     Example: { playerName: "Steve", count: 5 }
      *                                     Placeholders in the string should be like %%placeholderName%%.
-     * @param {(Player|string|null)} [targetPlayerOrLangCode=null] - Optional. A Player object to get user-specific language,
-     *                                                              or a language code string. If null or invalid,
-     *                                                              uses server default or ultimately "en_US".
-     * @returns {string} The translated and formatted string, or the key if not found.
+     * @returns {string} The translated and formatted string, or the key with placeholder data if not found.
      */
-    getText: function(key, placeholders = {}) { // Remove targetPlayerOrLangCode from parameters
+    getText: function(key, placeholders = {}) {
         let text = fallbackTranslations[key];
 
         if (typeof text !== 'string') {
             // If key is not in fallbackTranslations, construct a string that includes the key itself
             // and any provided placeholders, so it's clear what text is missing but also what data it had.
-            let missingMsg = key; // Start with the key itself
+            let missingMsg = `Missing translation for key: ${key}`; // Start with the key itself
             if (Object.keys(placeholders).length > 0) {
-                missingMsg += " (";
+                missingMsg += " (Data: ";
                 missingMsg += Object.entries(placeholders)
                     .map(([pk, pv]) => `${pk}: ${String(pv)}`)
                     .join(", ");
                 missingMsg += ")";
             }
-            // Do not attempt to replace placeholders in the 'key' string itself if it's being returned.
-            // The original placeholder replacement loop should only run if 'text' was found in fallbacks.
+            // Log this to the console for server admins to see, as this indicates a missing translation.
+            // console.warn(`[i18n] ${missingMsg}`); // Consider adding a log function if available and appropriate
             return missingMsg; // Return the key and its placeholder values
         }
 
@@ -182,14 +174,4 @@ export const i18n = {
         }
         return text;
     },
-
-    // Removed: reloadLanguages function
-    // Removed: setLanguage function
-    // Removed: getAvailableLanguages function
 };
-
-// It's good practice to ensure dynamic properties are loaded by a setup function.
-// For example, a function in Initialize.js could read the en_US.lang file content
-// (if possible through some mechanism like reading a structure block with the text, or if an API becomes available)
-// and set it to `world.setDynamicProperty("ac:lang/en_US", fileContentAsStringWithEscapedNewlines);`
-// For now, this i18n.js assumes `ac:lang/en_US` is somehow populated.

--- a/Anti Cheats BP/scripts/assets/ui.js
+++ b/Anti Cheats BP/scripts/assets/ui.js
@@ -2,7 +2,7 @@ import * as Minecraft from '@minecraft/server';
 import { ActionFormData, MessageFormData, ModalFormData } from '@minecraft/server-ui';
 import { addPlayerToUnbanQueue, copyInv, getPlayerByName, invsee, logDebug, millisecondTime, sendMessageToAllAdmins } from './util.js';
 import { ModuleStatusManager } from '../classes/module.js';
-import * as config from "../config.js";
+import CONFIG from "../config.js";
 // import { reportPlayerInternal } from '../command/src/report.js'; // No longer needed here, submitReport will be used
 import { submitReport } from '../systems/report_system.js';      // For submitting player reports
 import { i18n } from './i18n.js'; // Added for localization
@@ -244,7 +244,7 @@ export function showPlayerList(player) {
     if (owners.length > 0) {
         owners.forEach(p => {
             const ownerPrefix = i18n.getText("ui.playerlist.label.owner", { playerName: "" }); // Get prefix if any
-            const rankColor = config.default.ranks.owner.nameColor || "§c";
+            const rankColor = CONFIG.ranks.owner.nameColor || "§c";
             bodyText += `${ownerPrefix}${rankColor}${p.name}§r\n`;
         });
     } else {
@@ -257,7 +257,7 @@ export function showPlayerList(player) {
     if (admins.length > 0) {
         admins.forEach(p => {
             const adminPrefix = i18n.getText("ui.playerlist.label.admin", { playerName: "" }); // Get prefix if any
-            const rankColor = config.default.ranks.admin.nameColor || "§6";
+            const rankColor = CONFIG.ranks.admin.nameColor || "§6";
             bodyText += `${adminPrefix}${rankColor}${p.name}§r\n`;
         });
     } else {
@@ -270,10 +270,10 @@ export function showPlayerList(player) {
     if (normalPlayers.length > 0) {
         normalPlayers.forEach(p => {
             // Attempt to get specific rank color, fallback to member color
-            const playerRankId = p.getDynamicProperty("ac:rankId") || config.default.defaultRank;
-            const rankIdStr = typeof playerRankId === 'string' ? playerRankId : config.default.defaultRank;
-            const rankInfo = config.default.ranks[rankIdStr];
-            const rankColor = rankInfo ? rankInfo.nameColor : (config.default.ranks.member.nameColor || "§a");
+            const playerRankId = p.getDynamicProperty("ac:rankId") || CONFIG.defaultRank;
+            const rankIdStr = typeof playerRankId === 'string' ? playerRankId : CONFIG.defaultRank;
+            const rankInfo = CONFIG.ranks[rankIdStr];
+            const rankColor = rankInfo ? rankInfo.nameColor : (CONFIG.ranks.member.nameColor || "§a");
             // For normal players, usually no prefix like "[Rank]" is used unless specified by rankInfo.displayText
             // For simplicity here, just name with color.
             bodyText += `${rankColor}${p.name}§r\n`;
@@ -635,7 +635,7 @@ function showCommandLogDetailForm(player, logEntry, previousForm) {
 /**
  * Displays a settings selector form to the player.
  * Allows navigation to module settings, config editor, and config debug.
- * If `config.default.other.ownerOnlySettings` is true and player is not an owner, it prompts for owner login.
+ * If `CONFIG.other.ownerOnlySettings` is true and player is not an owner, it prompts for owner login.
  *
  * @export
  * @param {Minecraft.Player} player The player to show the settings selector to.
@@ -644,7 +644,7 @@ function showCommandLogDetailForm(player, logEntry, previousForm) {
  * @throws {Error} If an error occurs during UI display or interaction, especially related to owner login.
  */
 export function settingSelector(player, previousForm){ 
-	if (config.default.other.ownerOnlySettings && !player.isOwner()) return ownerLoginForm(player, settingSelector, previousForm);
+	if (CONFIG.other.ownerOnlySettings && !player.isOwner()) return ownerLoginForm(player, settingSelector, previousForm);
 
 	const form = new ActionFormData()
 		.title("§l§7Server Settings") 
@@ -977,7 +977,7 @@ export async function showBanLogFilterSortForm(player, currentOptions = {}) {
 
 /**
  * Displays an owner login form.
- * If the correct owner password (from `config.default.OWNER_PASSWORD`) is entered,
+ * If the correct owner password (from `CONFIG.OWNER_PASSWORD`) is entered,
  * sets temporary owner status for the player and proceeds to `nextForm`.
  *
  * @param {Minecraft.Player} player The player attempting to log in.
@@ -987,7 +987,7 @@ export async function showBanLogFilterSortForm(player, currentOptions = {}) {
  * @throws {Error} If an error occurs during UI display or interaction.
  */
 function ownerLoginForm(player, nextForm, previousFormForNext){
-	if(!config.default.OWNER_PASSWORD){
+	if(!CONFIG.OWNER_PASSWORD){
 		player.sendMessage(`§6[§eAnti Cheats§6]§4 Error!§c You have not set an owner password inside of the configuration file, access denied.`);
 		if (previousFormForNext) return previousFormForNext(player); 
 		return;
@@ -1000,7 +1000,7 @@ function ownerLoginForm(player, nextForm, previousFormForNext){
 			if (previousFormForNext) return previousFormForNext(player); 
 			return;
 		}
-		if (formData.formValues[0] === config.default.OWNER_PASSWORD) {
+		if (formData.formValues[0] === CONFIG.OWNER_PASSWORD) {
 			player.sendMessage("§6[§eAnti Cheats§6]§a Access granted, you now have owner status.");
 			player.setDynamicProperty("ac:ownerStatus",true);
 			player.setDynamicProperty("ac:rankId" ,"owner"); 
@@ -1042,7 +1042,7 @@ function configDebugForm(player, previousForm){
 		if (formData.canceled) return previousForm(player);
 		switch (formData.selection) {
 			case 0:
-				console.warn(JSON.stringify(config.default));
+				console.warn(JSON.stringify(CONFIG));
 				player.sendMessage(`§6[§eAnti Cheats§6]§f The config was exported to the console`);
                 return configDebugForm(player, previousForm); 
 			case 1:
@@ -1062,7 +1062,7 @@ function configDebugForm(player, previousForm){
 
 /**
  * Displays a configuration editor form.
- * Allows editing different modules of the `config.default` object.
+ * Allows editing different modules of the `CONFIG` object.
  * Requires owner privileges; prompts for login if the player is not an owner.
  *
  * @param {Minecraft.Player} player The player using the config editor.
@@ -1076,7 +1076,7 @@ function configEditorForm(player, previousForm) {
 	const mainConfigForm = new ActionFormData()
 		.title("§l§7Config Editor - Modules") 
 		.body("Select a configuration module to edit its settings."); 
-	const configOptions = Object.keys(config.default).filter(key => typeof config.default[key] === "object");
+	const configOptions = Object.keys(CONFIG).filter(key => typeof CONFIG[key] === "object");
 
 	for (let i = 0; i < configOptions.length; i++) {
 		mainConfigForm.button(configOptions[i], "textures/ui/document_glyph.png"); 
@@ -1093,7 +1093,7 @@ function configEditorForm(player, previousForm) {
 		const configModuleForm = new ModalFormData();
 		configModuleForm.title(`§l§7Edit: ${selectedModule}`); 
 
-		const configModuleOptions = Object.entries(config.default[selectedModule]);
+		const configModuleOptions = Object.entries(CONFIG[selectedModule]);
 		const formFields = []; 
 
 		for (const [key, value] of configModuleOptions) {
@@ -1134,7 +1134,7 @@ function configEditorForm(player, previousForm) {
 
 			formFields.forEach((fieldPath, index) => {
 				const keys = fieldPath.split('.');
-				let target = config.default[selectedModule];
+				let target = CONFIG[selectedModule];
 
 				for (let i = 0; i < keys.length - 1; i++) {
 					target = target[keys[i]];
@@ -1156,7 +1156,7 @@ function configEditorForm(player, previousForm) {
 						break;
 				}
 			});
-			world.setDynamicProperty("ac:config",JSON.stringify(config.default)); 
+			world.setDynamicProperty("ac:config",JSON.stringify(CONFIG)); 
 
 			player.sendMessage(`§6[§eAnti Cheats§6]§r Configuration updated successfully!`);
 		}).catch(e => {
@@ -1453,7 +1453,7 @@ export async function showPlayerList_Public(player) {
 }
 
 export async function showPublicInfoPanel(player) {
-    const uiSettings = config.default.uiSettings;
+    const uiSettings = CONFIG.uiSettings;
     const featuresEnabled = uiSettings.featuresEnabled;
 
     const form = new ActionFormData();
@@ -1519,7 +1519,7 @@ async function showSystemInfo(player) {
     const form = new MessageFormData();
     form.title("System Information");
 
-    const uiSettings = config.default.uiSettings;
+    const uiSettings = CONFIG.uiSettings;
     const serverIP = uiSettings.serverIP || "Not Set";
     const serverPort = uiSettings.serverPort || "Not Set";
     
@@ -1648,7 +1648,7 @@ async function showReportPlayerForm(player) {
 
 async function showCustomLink(player) {
     const form = new MessageFormData();
-    const uiSettings = config.default.uiSettings;
+    const uiSettings = CONFIG.uiSettings;
     const linkTitle = uiSettings.customLinkTitle || "Our Link";
     const linkURL = uiSettings.customLinkURL || "No URL configured.";
 
@@ -1681,7 +1681,7 @@ async function showRules(player) {
     const form = new MessageFormData();
     form.title("Server Rules");
 
-    const uiSettings = config.default.uiSettings;
+    const uiSettings = CONFIG.uiSettings;
     const rules = uiSettings.rules || "No rules defined."; // Fallback if rules are not set
 
     form.body(rules.replace(/\\n/g, '\n')); // Replace escaped newlines with actual newlines for display
@@ -1778,7 +1778,7 @@ async function showServerInfo(player) {
     const form = new MessageFormData();
     form.title("Server Information");
 
-    const uiSettings = config.default.uiSettings;
+    const uiSettings = CONFIG.uiSettings;
     const welcomeMessage = uiSettings.welcomeMessage || "Welcome!";
     const currentTimeTicks = world.getTime(); // Gets total world time in ticks
     // Convert ticks to a more readable format (e.g., Day X, HH:MM)

--- a/Anti Cheats BP/scripts/command/importer.js
+++ b/Anti Cheats BP/scripts/command/importer.js
@@ -35,8 +35,6 @@ import "./src/offlineban.js";
 import "./src/offlineunban.js";
 import "./src/teleport.js";
 import "./src/ui.js"; // Added for the new !ui command
-import "./src/setserverlanguage.js";
-import "./src/mylanguage.js";
 import "./src/commands/owner.js";
 import "./src/panel.js"; // Added for the new !panel command
 

--- a/Anti Cheats BP/scripts/config.js
+++ b/Anti Cheats BP/scripts/config.js
@@ -293,7 +293,7 @@ export default {
         "k": "kick",
         "m": "mute",
         "um": "unmute",
-        "p": "pardon",
+        "p": "unban",
         "uban": "unban",
         "ofb": "offlineban",
         "ofub": "offlineunban",
@@ -313,6 +313,16 @@ export default {
         "ci": "copyinv",
         "wb": "worldborder",
         "t": "teleport",
-        "tpl": "teleport"
+        "tpl": "teleport",
+        "cbl": "clearbanlogs",
+        "fj": "fakejoin",
+        "n": "notify",
+        "admP": "panel",
+        "rmo": "removeowner",
+        "rp": "report",
+        "snpc": "summon_npc",
+        "tdb": "toggledeviceban",
+        "gui": "ui",
+        "own": "owner"
     }
 }

--- a/Anti Cheats BP/scripts/index.js
+++ b/Anti Cheats BP/scripts/index.js
@@ -2,7 +2,7 @@ import { world, system } from '@minecraft/server'; // Ensure system and world ar
 import * as Minecraft from '@minecraft/server'; // For types like Player, GameMode, etc.
 
 // Local Script Imports
-import * as config from "./config.js"; // Assuming this is still CONFIG.default structure
+import CONFIG from "./config.js"; // Assuming this is still CONFIG.default structure
 import { i18n } from './assets/i18n.js';
 import "./command/importer.js"; // Still needed for command registration?
 import "./slash_commands.js"; // Still needed for slash command registration?
@@ -78,8 +78,8 @@ system.run(() => { // Final initialization run
 system.run(async () => {
     try {
         const currentVersion = world.getDynamicProperty("ac:version");
-        if (currentVersion !== config.version) { // Assuming config is now CONFIG.default -> CONFIG
-            world.setDynamicProperty("ac:version", config.version);
+        if (currentVersion !== CONFIG.version) { // Assuming config is now CONFIG.default -> CONFIG
+            world.setDynamicProperty("ac:version", CONFIG.version);
             // Potentially send a message to admins about the update if it's a significant version change
             // This could also be part of Initialize() or a dedicated update/migration script.
         }


### PR DESCRIPTION
This commit addresses your feedback to:
1. Update command aliases in `config.js` to be more comprehensive.
   - Added aliases for commands like clearbanlogs, fakejoin, notify, panel, removeowner, report, summon_npc, toggledeviceban, ui, owner.
   - Retargeted alias "p" from non-existent "pardon" to "unban".

2. Remove internationalization (i18n) features as the addon will be English-only.
   - Deleted `assets/language_data.js`.
   - Updated `command/importer.js` to reflect deleted command files.
   - Simplified `assets/i18n.js` to remove all multi-language support code, relying solely on its internal fallbackEnglish translations. Removed unused CONFIG import.

3. Fix inconsistencies:
   - Updated `assets/ui.js` to use the correct import `CONFIG from "../config.js"` instead of `import * as config` and adjusted usages accordingly.

The addon is now streamlined for English-only use with more complete command aliasing.