### PR TITLE
Fix: Resolve TypeErrors related to module status checks

### DIFF
--- a/Anti Cheats BP/scripts/classes/module.js
+++ b/Anti Cheats BP/scripts/classes/module.js
@@ -72,6 +72,10 @@ class ModuleStatusManagerInternal { // Renamed from ACModuleInternal
     
         return world.getDynamicProperty(`ac:${this.getModuleID(module)}`) ?? false;
     }
+
+    isActive(moduleName) {
+        return this.getModuleStatus(moduleName);
+    }
     /**
      * Toggles the status of a given module (enabled to disabled, or vice-versa).
      * Persists the change in a world dynamic property.


### PR DESCRIPTION
I've added the 'isActive' method to the ModuleStatusManagerInternal class. This method was being called in 'world_interaction_handlers.js' but was not defined, leading to TypeErrors. It now correctly calls 'getModuleStatus'.

This change is expected to resolve the TypeErrors reported at:
- handlers/world_interaction_handlers.js:128 (related to 'setPermutation')
- systems/periodic_checks.js:122 (related to 'getModuleStatus')

By ensuring 'isActive' is defined, the module status checks will function correctly, allowing proper script execution flow and preventing downstream errors.