### PR TITLE
Fix: Correct module calls and attempt TypeError fix for periodic_checks

### DIFF
--- a/Anti Cheats BP/scripts/classes/module.js
+++ b/Anti Cheats BP/scripts/classes/module.js
@@ -72,6 +72,10 @@ class ModuleStatusManagerInternal { // Renamed from ACModuleInternal
     
         return world.getDynamicProperty(`ac:${this.getModuleID(module)}`) ?? false;
     }
+
+    isActive(moduleName) {
+        return this.getModuleStatus(moduleName);
+    }
     /**
      * Toggles the status of a given module (enabled to disabled, or vice-versa).
      * Persists the change in a world dynamic property.

--- a/Anti Cheats BP/scripts/handlers/world_interaction_handlers.js
+++ b/Anti Cheats BP/scripts/handlers/world_interaction_handlers.js
@@ -13,7 +13,7 @@ world.afterEvents.itemUse.subscribe((eventData) => {
     const item = eventData.itemStack;
 
     // Trident High Damage / Fly Check (Module based)
-    if (item.typeId === "minecraft:trident" && ModuleStatusManager.isActive("trident")) {
+    if (item.typeId === "minecraft:trident" && ModuleStatusManager.isActive(ModuleStatusManager.Modules.tridentCheck)) {
         // Logic for trident high damage/fly would be here or called from here.
         // This might involve checking player velocity changes, if they are Riptide enchanted, etc.
         // Example: player.setDynamicProperty("last_used_trident_time", world.currentTick);
@@ -35,7 +35,7 @@ world.beforeEvents.itemUse.subscribe((eventData) => {
     const item = eventData.itemStack;
 
     // Anti-Grief: Prevent use of certain items if module is active
-    if (ModuleStatusManager.isActive("antigrief") && configData.restricted_items_antigrief.includes(item.typeId)) {
+    if (ModuleStatusManager.isActive(ModuleStatusManager.Modules.antiGrief) && configData.restricted_items_antigrief.includes(item.typeId)) {
         if (!player.hasAdmin()) { // Allow admins to use restricted items
             eventData.cancel = true;
             player.sendMessage(i18n.getText("system.antigrief_item_restriction", { item: item.typeId }, player));
@@ -59,11 +59,11 @@ world.afterEvents.playerBreakBlock.subscribe((eventData) => {
     }
 
     const nukerConfig = configData.nuker_detection; // Assuming nuker config is structured like this
-    const antiNukerActive = ModuleStatusManager.isActive("nuker");
-    const autoModOn = ModuleStatusManager.isActive("automod"); // Assuming an automod module status
+    const antiNukerActive = ModuleStatusManager.isActive(ModuleStatusManager.Modules.nukerCheck);
+    const autoModOn = ModuleStatusManager.isActive(ModuleStatusManager.Modules.autoMod); // Assuming an automod module status
 
     // Anti-Grief: Log block breaks (moved before nuker for clarity, can be anywhere)
-    if (ModuleStatusManager.isActive("antigrief") && configData.log_block_breaks_antigrief) {
+    if (ModuleStatusManager.isActive(ModuleStatusManager.Modules.antiGrief) && configData.log_block_breaks_antigrief) {
         // console.warn(`[AntiGrief] ${player.name} broke ${blockId}`);
     }
 
@@ -125,7 +125,7 @@ world.afterEvents.entitySpawn.subscribe((eventData) => {
     const entity = eventData.entity;
 
     // Anti-Grief: Prevent spawning of certain entities if module is active
-    if (ModuleStatusManager.isActive("antigrief")) {
+    if (ModuleStatusManager.isActive(ModuleStatusManager.Modules.antiGrief)) {
         const restrictedEntities = configData?.restricted_entities_antigrief;
         if (Array.isArray(restrictedEntities) && restrictedEntities.includes(entity.typeId)) {
             // Check if spawned by a player and if that player is not an admin

--- a/Anti Cheats BP/scripts/systems/periodic_checks.js
+++ b/Anti Cheats BP/scripts/systems/periodic_checks.js
@@ -101,7 +101,8 @@ system.runInterval(() => {
             }
 
             // Nuker VL decay/check
-            if (ModuleStatusManager.getModuleStatus(ModuleStatusManager.Modules.nukerCheck)) {
+            const getStatusFunc = ModuleStatusManager.getModuleStatus;
+            if (getStatusFunc.call(ModuleStatusManager, ModuleStatusManager.Modules.nukerCheck)) {
                 let nukerBreakVl = state.nukerVLBreak || 0; // Read from state
                 if (nukerBreakVl > CONFIG.world.nuker.maxBlocks) {
                      sendMessageToAllAdmins("detection.nuker_detected_admin", { player: player.name, blocks: nukerBreakVl });


### PR DESCRIPTION
- In `world_interaction_handlers.js`:
  - I corrected `ModuleStatusManager.isActive("antigrief")` on line 145 to use `ModuleStatusManager.Modules.antiGrief`. This is the likely fix for the persistent `ReferenceError`.
  - I standardized `ModuleStatusManager.isActive("trident")` on line 15 to use `ModuleStatusManager.Modules.tridentCheck`, assuming `tridentCheck` is a defined module key.

- In `periodic_checks.js`:
  - I changed the invocation of `ModuleStatusManager.getModuleStatus` (around line 102) to use an intermediate function variable and `.call()` to ensure the `this` context is correctly set for `ModuleStatusManager`. This is a further attempt to resolve the persistent `TypeError: not a function`.