### PR TITLE
feat: Rename acnotifications to notify and enhance !help

### DIFF
--- a/AntiCheatsBP/scripts/config.js
+++ b/AntiCheatsBP/scripts/config.js
@@ -238,6 +238,13 @@ export const XRAY_DETECTION_MONITORED_ORES = [
 /** @type {boolean} If true, admins will receive X-Ray mining notifications by default, unless they explicitly turn them off. */
 export const XRAY_DETECTION_ADMIN_NOTIFY_BY_DEFAULT = true;
 
+/**
+ * @type {boolean}
+ * If true, admins will receive all AntiCheat system notifications by default,
+ * unless they explicitly turn them off using !acnotifications off.
+ */
+export const AC_GLOBAL_NOTIFICATIONS_DEFAULT_ON = true;
+
 // --- System ---
 
 /** @type {string} The current version of the AntiCheat system. */
@@ -257,6 +264,9 @@ export const commandAliases = {
     "i": "inspect",
     "rf": "resetflags",
     "xn": "xraynotify",
-    "mf": "myflags"
+    "mf": "myflags",
+    "acnotifications": "notify",
+    "acenotify": "notify",
+    "notifications": "notify"
     // Add more aliases as commands are developed
 };


### PR DESCRIPTION
This commit introduces two main improvements based on your feedback:

1.  **Command Rename and Aliases**:
    - The `!acnotifications` command has been renamed to `!notify` for brevity.
    - Its syntax is now `!notify <on|off|status>`.
    - Aliases have been added in `config.js` for backward compatibility and flexibility: "acnotifications", "acenotify", and "notifications" all now point to the "notify" command.

2.  **Help Command Enhancement (`!help`)**:
    - The `!help` command now supports providing a command name as an argument (e.g., `!help kick` or `!help notify`).
    - If a command name is provided:
        - It looks up the command (checking both direct names and aliases).
        - If found and you have permission, it displays detailed help including full syntax, description, and the required permission level (name and numeric value). - Appropriate messages are shown if the command isn't found or you lack permission.
    - If `!help` is used without arguments, it continues to list all commands available to you based on your permission level, with an updated introductory message.