### PR TITLE
Remove unused @minecraft/server-gametest dependency

### DIFF
--- a/AntiCheatsBP/manifest.json
+++ b/AntiCheatsBP/manifest.json
@@ -41,10 +41,6 @@
       "version": "2.0.0"
     },
     {
-      "module_name": "@minecraft/server-gametest",
-      "version": "1.0.0-beta"
-    },
-    {
       "module_name": "@minecraft/server-ui",
       "version": "2.0.0"
     },


### PR DESCRIPTION
This commit removes the @minecraft/server-gametest dependency from AntiCheatsBP/manifest.json as it was found to be unused in your project's scripts.