### PR TITLE
Fix: Correct import paths in config.js

### DIFF
--- a/AntiCheatsBP/scripts/config.js
+++ b/AntiCheatsBP/scripts/config.js
@@ -1,6 +1,6 @@
 // Anti-Cheat Configuration File
-import { checkActionProfiles } from '../core/actionProfiles.js';
-import { automodConfig as importedAutoModConfig } from '../core/automodConfig.js';
+import { checkActionProfiles } from './core/actionProfiles.js';
+import { automodConfig as importedAutoModConfig } from './core/automodConfig.js';
 
 // General Admin & System
 /** @type {string} The tag for identifying admin players. */


### PR DESCRIPTION
Changed ../core/actionProfiles.js to ./core/actionProfiles.js and ../core/automodConfig.js to ./core/automodConfig.js in AntiCheatsBP/scripts/config.js.

These incorrect relative paths caused a 'module not found' error when main.js was loaded, as config.js was trying to navigate up one directory too far.