### PR TITLE
Refactor: Organize check scripts into correct categories

### DIFF
--- a/AntiCheatsBP/scripts/checks/index.js
+++ b/AntiCheatsBP/scripts/checks/index.js
@@ -11,7 +11,6 @@ export * from './movement/speedCheck.js';
 export * from './movement/noFallCheck.js';
 export { checkNoSlow } from './movement/noSlowCheck.js';
 export { checkInvalidSprint } from './movement/invalidSprintCheck.js';
-export * from './movement/netherRoofCheck.js';
 
 // Combat Checks
 export * from './combat/reachCheck.js';
@@ -27,15 +26,16 @@ export { checkTower, checkFlatRotationBuilding, checkDownwardScaffold, checkAirP
 export { checkFastUse } from './world/fastUseCheck.js';
 export { checkAutoTool } from './world/autoToolCheck.js';
 export { checkBreakUnbreakable, checkBreakSpeed } from './world/instaBreakCheck.js';
-export { checkNameSpoof } from './world/nameSpoofCheck.js';
-export { checkAntiGMC } from './world/antiGMCCheck.js';
 export { checkEntitySpam } from './world/entityChecks.js';
 export { checkPistonLag } from './world/pistonChecks.js';
+export * from './world/netherRoofCheck.js';
 
 // Player Behavior Checks
 export { checkSwitchAndUseInSameTick, checkInventoryMoveWhileActionLocked } from './player/inventoryModCheck.js';
 export { checkSelfHurt } from './player/selfHurtCheck.js';
 export { checkInvalidRenderDistance } from './player/clientInfoChecks.js';
+export { checkAntiGMC } from './player/antiGMCCheck.js';
+export { checkNameSpoof } from './player/nameSpoofCheck.js';
 
 // Chat Checks
 export { checkMessageRate } from './chat/messageRateCheck.js';

--- a/AntiCheatsBP/scripts/checks/player/antiGMCCheck.js
+++ b/AntiCheatsBP/scripts/checks/player/antiGMCCheck.js
@@ -1,5 +1,5 @@
 /**
- * @file AntiCheatsBP/scripts/checks/world/antiGMCCheck.js
+ * @file AntiCheatsBP/scripts/checks/player/antiGMCCheck.js
  * Implements a check to detect and optionally correct players who are in Creative Mode
  * without proper authorization (e.g., not an admin or owner).
  * @version 1.1.1

--- a/AntiCheatsBP/scripts/checks/player/nameSpoofCheck.js
+++ b/AntiCheatsBP/scripts/checks/player/nameSpoofCheck.js
@@ -1,5 +1,5 @@
 /**
- * @file AntiCheatsBP/scripts/checks/world/nameSpoofCheck.js
+ * @file AntiCheatsBP/scripts/checks/player/nameSpoofCheck.js
  * Implements a check to detect player name spoofing attempts, including names that are too long,
  * contain disallowed characters, or are changed too rapidly.
  * Relies on `pData` fields like `lastKnownNameTag` and `lastNameTagChangeTick`.

--- a/AntiCheatsBP/scripts/checks/world/netherRoofCheck.js
+++ b/AntiCheatsBP/scripts/checks/world/netherRoofCheck.js
@@ -1,5 +1,5 @@
 /**
- * @file AntiCheatsBP/scripts/checks/movement/netherRoofCheck.js
+ * @file AntiCheatsBP/scripts/checks/world/netherRoofCheck.js
  * Checks if a player is on the Nether roof.
  * @version 1.0.1
  */


### PR DESCRIPTION
I moved several check scripts to more appropriate directories:

- `netherRoofCheck.js` moved from `movement/` to `world/`
- `antiGMCCheck.js` moved from `world/` to `player/`
- `nameSpoofCheck.js` moved from `world/` to `player/`

I updated JSDoc `@file` tags in the moved files to reflect their new paths. I adjusted export statements in `AntiCheatsBP/scripts/checks/index.js` to ensure all checks are correctly imported and exported from their new locations and categorized appropriately.