### PR TITLE
Fix: Correct syntax error in automodManager.js

### DIFF
--- a/AntiCheatsBP/scripts/core/automodManager.js
+++ b/AntiCheatsBP/scripts/core/automodManager.js
@@ -14,7 +14,7 @@
  */
 function formatDuration(ms, getStringFn) {
     if (ms === Infinity) return getStringFn("common.value.permanent");
-    if (ms < 1000) return \`\${ms}ms\`;
+    if (ms < 1000) return `${ms}ms`;
 
     let seconds = Math.floor(ms / 1000);
     let minutes = Math.floor(seconds / 60);

--- a/AntiCheatsBP/scripts/core/playerDataManager.js
+++ b/AntiCheatsBP/scripts/core/playerDataManager.js
@@ -505,7 +505,7 @@ export async function addFlag(player, flagType, reasonMessage, detailsForNotify 
             quantityFound: detailsForNotify.quantityFound || 0,
             timestamp: Date.now()
         };
-        playerUtils.debugLog(dependencies, \`PDM:addFlag: Stored violation details for \${flagType} on \${player.nameTag}: \${JSON.stringify(pData.lastViolationDetailsMap[flagType])}\`, player.nameTag);
+        playerUtils.debugLog(dependencies, `PDM:addFlag: Stored violation details for ${flagType} on ${player.nameTag}: ${JSON.stringify(pData.lastViolationDetailsMap[flagType])}`, player.nameTag);
     }
 
     pData.isDirtyForSave = true;


### PR DESCRIPTION
Removes an erroneous backslash character that was present at the beginning of a template literal string on line 17 in AntiCheatsBP/scripts/core/automodManager.js. This was causing a SyntaxError.