### PR TITLE
Fix: Correct all remaining malformed object keys in en_US.js

### DIFF
--- a/AntiCheatsBP/scripts/core/automodManager.js
+++ b/AntiCheatsBP/scripts/core/automodManager.js
@@ -14,7 +14,7 @@
  */
 function formatDuration(ms, getStringFn) {
     if (ms === Infinity) return getStringFn("common.value.permanent");
-    if (ms < 1000) return \`\${ms}ms\`;
+    if (ms < 1000) return `${ms}ms`;
 
     let seconds = Math.floor(ms / 1000);
     let minutes = Math.floor(seconds / 60);
@@ -26,10 +26,10 @@ function formatDuration(ms, getStringFn) {
     hours %= 24;
 
     const parts = [];
-    if (days > 0) parts.push(\`\${days}d\`);
-    if (hours > 0) parts.push(\`\${hours}h\`);
-    if (minutes > 0) parts.push(\`\${minutes}m\`);
-    if (seconds > 0 || parts.length === 0) parts.push(\`\${seconds}s\`);
+    if (days > 0) parts.push(`${days}d`);
+    if (hours > 0) parts.push(`${hours}h`);
+    if (minutes > 0) parts.push(`${minutes}m`);
+    if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
 
     return parts.join(' ');
 }
@@ -41,7 +41,7 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
     const { playerUtils, logManager, config, playerDataManager, getString } = dependencies; // Removed commandModules
     const currentAutomodConfig = config.automodConfig;
 
-    playerUtils.debugLog(dependencies, \`[AutoModManager] Dispatching action '\${actionType}' for \${player.nameTag} due to \${checkType}. Params: \${JSON.stringify(parameters)}\`, player.nameTag);
+    playerUtils.debugLog(dependencies, `[AutoModManager] Dispatching action '${actionType}' for ${player.nameTag} due to ${checkType}. Params: ${JSON.stringify(parameters)}`, player.nameTag);
 
     let actionProcessed = false;
     let logDetails = "";
@@ -56,10 +56,10 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
 
             if (playerUtils.warnPlayer) {
                 playerUtils.warnPlayer(player, localizedMessageWarn);
-                logDetails = \`Warned player. Check: \${checkType}, Reason: \${localizedMessageWarn}\`;
+                logDetails = `Warned player. Check: ${checkType}, Reason: ${localizedMessageWarn}`;
                 actionProcessed = true;
             } else {
-                playerUtils.debugLog(dependencies, \`[AutoModManager] playerUtils.warnPlayer not found for WARN action.\`, player.nameTag);
+                playerUtils.debugLog(dependencies, `[AutoModManager] playerUtils.warnPlayer not found for WARN action.`, player.nameTag);
             }
             break;
         case "kick":
@@ -69,11 +69,11 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
 
             try {
                 player.kick(localizedKickReason);
-                logDetails = \`Kicked player. Check: \${checkType}, Reason: \${localizedKickReason}\`;
+                logDetails = `Kicked player. Check: ${checkType}, Reason: ${localizedKickReason}`;
                 actionProcessed = true;
             } catch (e) {
-                playerUtils.debugLog(dependencies, \`[AutoModManager] Error kicking player \${player.nameTag}: \${e.stack || e}\`, player.nameTag);
-                logDetails = \`Failed to kick player \${player.nameTag}. Check: \${checkType}, Reason: \${localizedKickReason}, Error: \${e.stack || e}\`;
+                playerUtils.debugLog(dependencies, `[AutoModManager] Error kicking player ${player.nameTag}: ${e.stack || e}`, player.nameTag);
+                logDetails = `Failed to kick player ${player.nameTag}. Check: ${checkType}, Reason: ${localizedKickReason}, Error: ${e.stack || e}`;
                 if (logManager?.addLog) {
                     logManager.addLog('error', {
                         event: 'automod_kick_failure',
@@ -94,7 +94,7 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
 
             let parsedDurationMsTempBan = playerUtils.parseDuration(durationStringTempBan);
             if (parsedDurationMsTempBan === null || (parsedDurationMsTempBan <= 0 && parsedDurationMsTempBan !== Infinity)) {
-                playerUtils.debugLog(dependencies, \`[AutoModManager] Invalid duration string "\${durationStringTempBan}" for TEMP_BAN on \${player.nameTag}. Defaulting to 5m.\`, player.nameTag);
+                playerUtils.debugLog(dependencies, `[AutoModManager] Invalid duration string "${durationStringTempBan}" for TEMP_BAN on ${player.nameTag}. Defaulting to 5m.`, player.nameTag);
                 parsedDurationMsTempBan = 300000; // 5 minutes
             }
 
@@ -107,16 +107,16 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
                 const kickMsgHeader = getString("automod.kickMessage.tempban.header");
                 const kickMsgReasonPart = getString("automod.kickMessage.common.reason", { reason: localizedReasonMsgTempBan });
                 const kickMsgDurationPart = getString("automod.kickMessage.common.duration", { duration: friendlyDuration });
-                const kickMsgTempBan = \`\${kickMsgHeader}\n\${kickMsgReasonPart}\n\${kickMsgDurationPart}\`;
+                const kickMsgTempBan = `${kickMsgHeader}\n${kickMsgReasonPart}\n${kickMsgDurationPart}`;
 
                 adminNotifyDetails = getString("automod.adminNotify.details.duration", { duration: friendlyDuration });
                 try {
                     player.kick(kickMsgTempBan);
-                    logDetails = \`Temp banned player for \${friendlyDuration}. Check: \${checkType}, Reason: \${localizedReasonMsgTempBan}\`;
+                    logDetails = `Temp banned player for ${friendlyDuration}. Check: ${checkType}, Reason: ${localizedReasonMsgTempBan}`;
                     actionProcessed = true;
                 } catch (e) {
-                    playerUtils.debugLog(dependencies, \`[AutoModManager] Error kicking player \${player.nameTag} after TEMP_BAN: \${e.stack || e}\`, player.nameTag);
-                    logDetails = \`Temp banned player (kick failed). Duration: \${friendlyDuration}, Check: \${checkType}, Reason: \${localizedReasonMsgTempBan}, Error: \${e.stack || e}\`;
+                    playerUtils.debugLog(dependencies, `[AutoModManager] Error kicking player ${player.nameTag} after TEMP_BAN: ${e.stack || e}`, player.nameTag);
+                    logDetails = `Temp banned player (kick failed). Duration: ${friendlyDuration}, Check: ${checkType}, Reason: ${localizedReasonMsgTempBan}, Error: ${e.stack || e}`;
                     if (logManager?.addLog) {
                         logManager.addLog('error', {
                             event: 'automod_kick_failure',
@@ -129,8 +129,8 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
                     actionProcessed = true; // Ban was applied, kick failed
                 }
             } else {
-                playerUtils.debugLog(dependencies, \`[AutoModManager] Failed to apply TEMP_BAN to \${player.nameTag} via playerDataManager.addBan.\`, player.nameTag);
-                logDetails = \`Failed to apply TEMP_BAN. Check: \${checkType}, Reason: \${localizedReasonMsgTempBan}\`;
+                playerUtils.debugLog(dependencies, `[AutoModManager] Failed to apply TEMP_BAN to ${player.nameTag} via playerDataManager.addBan.`, player.nameTag);
+                logDetails = `Failed to apply TEMP_BAN. Check: ${checkType}, Reason: ${localizedReasonMsgTempBan}`;
                 if (logManager?.addLog) {
                     logManager.addLog('error', {
                         event: 'automod_addBan_failure',
@@ -156,15 +156,15 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
 
                 const kickMsgHeaderPerm = getString("automod.kickMessage.permban.header");
                 const kickMsgReasonPartPerm = getString("automod.kickMessage.common.reason", { reason: localizedReasonMsgPermBan });
-                const kickMsgPermBan = \`\${kickMsgHeaderPerm}\n\${kickMsgReasonPartPerm}\`;
+                const kickMsgPermBan = `${kickMsgHeaderPerm}\n${kickMsgReasonPartPerm}`;
 
                 try {
                     player.kick(kickMsgPermBan);
-                    logDetails = \`Permanently banned player. Check: \${checkType}, Reason: \${localizedReasonMsgPermBan}\`;
+                    logDetails = `Permanently banned player. Check: ${checkType}, Reason: ${localizedReasonMsgPermBan}`;
                     actionProcessed = true;
                 } catch (e) {
-                    playerUtils.debugLog(dependencies, \`[AutoModManager] Error kicking player \${player.nameTag} after PERM_BAN: \${e.stack || e}\`, player.nameTag);
-                    logDetails = \`Permanently banned player (kick failed). Check: \${checkType}, Reason: \${localizedReasonMsgPermBan}, Error: \${e.stack || e}\`;
+                    playerUtils.debugLog(dependencies, `[AutoModManager] Error kicking player ${player.nameTag} after PERM_BAN: ${e.stack || e}`, player.nameTag);
+                    logDetails = `Permanently banned player (kick failed). Check: ${checkType}, Reason: ${localizedReasonMsgPermBan}, Error: ${e.stack || e}`;
                     if (logManager?.addLog) {
                         logManager.addLog('error', {
                             event: 'automod_kick_failure',
@@ -177,8 +177,8 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
                     actionProcessed = true; // Ban was applied, kick failed
                 }
             } else {
-                playerUtils.debugLog(dependencies, \`[AutoModManager] Failed to apply PERM_BAN to \${player.nameTag} via playerDataManager.addBan.\`, player.nameTag);
-                logDetails = \`Failed to apply PERM_BAN. Check: \${checkType}, Reason: \${localizedReasonMsgPermBan}\`;
+                playerUtils.debugLog(dependencies, `[AutoModManager] Failed to apply PERM_BAN to ${player.nameTag} via playerDataManager.addBan.`, player.nameTag);
+                logDetails = `Failed to apply PERM_BAN. Check: ${checkType}, Reason: ${localizedReasonMsgPermBan}`;
                 if (logManager?.addLog) {
                     logManager.addLog('error', {
                         event: 'automod_addBan_failure',
@@ -203,7 +203,7 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
             if (muteSuccess) {
                 durationForLog = parsedDurationMsMute;
                 adminNotifyDetails = getString("automod.adminNotify.details.duration", { duration: formatDuration(durationForLog, getString) });
-                logDetails = \`Muted player. Duration: \${formatDuration(durationForLog, getString)}, Check: \${checkType}, Reason: \${localizedReasonMsgMute}\`;
+                logDetails = `Muted player. Duration: ${formatDuration(durationForLog, getString)}, Check: ${checkType}, Reason: ${localizedReasonMsgMute}`;
 
                 const muteNotificationToPlayer = getString("automod.playerNotification.mute", {
                     reason: localizedReasonMsgMute,
@@ -212,8 +212,8 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
                 playerUtils.warnPlayer(player, muteNotificationToPlayer);
                 actionProcessed = true;
             } else {
-                playerUtils.debugLog(dependencies, \`[AutoModManager] Failed to apply MUTE to \${player.nameTag} via playerDataManager.addMute.\`, player.nameTag);
-                logDetails = \`Failed to apply MUTE. Duration: \${durationStringMute}, Check: \${checkType}, Reason: \${localizedReasonMsgMute}\`;
+                playerUtils.debugLog(dependencies, `[AutoModManager] Failed to apply MUTE to ${player.nameTag} via playerDataManager.addMute.`, player.nameTag);
+                logDetails = `Failed to apply MUTE. Duration: ${durationStringMute}, Check: ${checkType}, Reason: ${localizedReasonMsgMute}`;
                 if (logManager?.addLog) {
                     logManager.addLog('error', {
                         event: 'automod_addMute_failure',
@@ -230,14 +230,14 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
             // const reasonMessageFreezeUnlocalized = currentAutomodConfig?.automodActionMessages?.[reasonKeyFreeze] || "automod.action.freezeDefaultReason";
             // const localizedReasonMsgFreeze = getString(reasonMessageFreezeUnlocalized);
 
-            playerUtils.debugLog(dependencies, \`[AutoModManager] 'freeze' action for \${player.nameTag} (check: \${checkType}) is currently a no-op. Direct freeze state management from automod is not yet implemented or command execution was removed.\`, player.nameTag);
-            logDetails = \`'freeze' action is not directly supported by AutoMod in this version. Check: \${checkType}. Player: \${player.nameTag}\`;
+            playerUtils.debugLog(dependencies, `[AutoModManager] 'freeze' action for ${player.nameTag} (check: ${checkType}) is currently a no-op. Direct freeze state management from automod is not yet implemented or command execution was removed.`, player.nameTag);
+            logDetails = `'freeze' action is not directly supported by AutoMod in this version. Check: ${checkType}. Player: ${player.nameTag}`;
             actionProcessed = false; // Mark as not processed to avoid incorrect success logging.
             break;
         case "removeIllegalItem":
             const itemTypeIdToRemove = parameters.itemToRemoveTypeId;
             if (!itemTypeIdToRemove) {
-                playerUtils.debugLog(dependencies, \`[AutoModManager] itemToRemoveTypeId not provided for REMOVE_ILLEGAL_ITEM on \${player.nameTag}.\`, player.nameTag);
+                playerUtils.debugLog(dependencies, `[AutoModManager] itemToRemoveTypeId not provided for REMOVE_ILLEGAL_ITEM on ${player.nameTag}.`, player.nameTag);
                 logDetails = "itemToRemoveTypeId missing in parameters for REMOVE_ILLEGAL_ITEM.";
                 actionProcessed = false;
                 break;
@@ -245,7 +245,7 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
             try {
                 const inventory = player.getComponent("minecraft:inventory");
                 if (!inventory?.container) {
-                    playerUtils.debugLog(dependencies, \`[AutoModManager] Could not get inventory for \${player.nameTag} for REMOVE_ILLEGAL_ITEM.\`, player.nameTag);
+                    playerUtils.debugLog(dependencies, `[AutoModManager] Could not get inventory for ${player.nameTag} for REMOVE_ILLEGAL_ITEM.`, player.nameTag);
                     logDetails = "Failed to get player inventory for REMOVE_ILLEGAL_ITEM.";
                     actionProcessed = false;
                     break;
@@ -268,15 +268,15 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
                     else player.sendMessage(removalMessage);
 
                     adminNotifyDetails = getString("automod.adminNotify.details.item", { item: itemTypeIdToRemove });
-                    logDetails = \`Removed \${removedCount}x \${itemTypeIdToRemove} from \${player.nameTag} (Check: \${checkType}).\`;
+                    logDetails = `Removed ${removedCount}x ${itemTypeIdToRemove} from ${player.nameTag} (Check: ${checkType}).`;
                 } else {
-                    logDetails = \`No items of type \${itemTypeIdToRemove} found to remove from \${player.nameTag} (Check: \${checkType}).\`;
+                    logDetails = `No items of type ${itemTypeIdToRemove} found to remove from ${player.nameTag} (Check: ${checkType}).`;
                 }
                 actionProcessed = true;
             } catch (e) {
-                playerUtils.debugLog(dependencies, \`[AutoModManager] Error during REMOVE_ILLEGAL_ITEM for \${player.nameTag} (\${itemTypeIdToRemove}): \${e.stack || e}\`, player.nameTag);
-                adminNotifyDetails = getString("common.error.generic") + \`: \${e.message || e}\`;
-                logDetails = \`Error removing item \${itemTypeIdToRemove}: \${e.stack || e}\`;
+                playerUtils.debugLog(dependencies, `[AutoModManager] Error during REMOVE_ILLEGAL_ITEM for ${player.nameTag} (${itemTypeIdToRemove}): ${e.stack || e}`, player.nameTag);
+                adminNotifyDetails = getString("common.error.generic") + `: ${e.message || e}`;
+                logDetails = `Error removing item ${itemTypeIdToRemove}: ${e.stack || e}`;
                 actionProcessed = false;
             }
             break;
@@ -288,7 +288,7 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
             const targetCoordinates = parameters.coordinates;
 
             if (!targetCoordinates || typeof targetCoordinates.y !== 'number') {
-                playerUtils.debugLog(dependencies, \`[AutoModManager] Invalid or missing coordinates for TELEPORT_SAFE on \${player.nameTag}. Y-coordinate is mandatory.\`, player.nameTag);
+                playerUtils.debugLog(dependencies, `[AutoModManager] Invalid or missing coordinates for TELEPORT_SAFE on ${player.nameTag}. Y-coordinate is mandatory.`, player.nameTag);
                 logDetails = `Invalid coordinates for TELEPORT_SAFE. Y-coordinate missing. Check: ${checkType}`;
                 actionProcessed = false;
                 break;
@@ -310,47 +310,47 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
                     } else {
                         player.sendMessage(localizedTeleportReason);
                     }
-                    logDetails = \`Teleported player to safe location near ${JSON.stringify(teleportLocation)}. Reason: ${localizedTeleportReason}\`;
+                    logDetails = `Teleported player to safe location near ${JSON.stringify(teleportLocation)}. Reason: ${localizedTeleportReason}`;
                     adminNotifyDetails = getString("automod.adminNotify.details.teleport", { x: safeLocation.x.toFixed(1), y: safeLocation.y.toFixed(1), z: safeLocation.z.toFixed(1) });
                     actionProcessed = true;
                 } else {
-                    playerUtils.debugLog(dependencies, \`[AutoModManager] No ideal safe location found for TELEPORT_SAFE near ${JSON.stringify(teleportLocation)} for ${player.nameTag}. Attempting direct teleport.\`, player.nameTag);
+                    playerUtils.debugLog(dependencies, `[AutoModManager] No ideal safe location found for TELEPORT_SAFE near ${JSON.stringify(teleportLocation)} for ${player.nameTag}. Attempting direct teleport.`, player.nameTag);
                     player.teleport(teleportLocation, { dimension: player.dimension });
                      if (playerUtils.warnPlayer) {
                         playerUtils.warnPlayer(player, localizedTeleportReason);
                     } else {
                         player.sendMessage(localizedTeleportReason);
                     }
-                    logDetails = \`Teleported player directly to ${JSON.stringify(teleportLocation)} (safe location search failed). Reason: ${localizedTeleportReason}\`;
+                    logDetails = `Teleported player directly to ${JSON.stringify(teleportLocation)} (safe location search failed). Reason: ${localizedTeleportReason}`;
                     adminNotifyDetails = getString("automod.adminNotify.details.teleport", { x: teleportLocation.x.toFixed(1), y: teleportLocation.y.toFixed(1), z: teleportLocation.z.toFixed(1) });
                     actionProcessed = true;
                 }
 
             } catch (e) {
-                playerUtils.debugLog(dependencies, \`[AutoModManager] Error teleporting player ${player.nameTag} for TELEPORT_SAFE: \${e.stack || e}\`, player.nameTag);
-                logDetails = \`Failed to teleport player \${player.nameTag} to ${JSON.stringify(teleportLocation)}. Reason: \${localizedTeleportReason}, Error: \${e.stack || e}\`;
-                adminNotifyDetails = getString("common.error.generic") + \`: \${e.message || e}\`;
+                playerUtils.debugLog(dependencies, `[AutoModManager] Error teleporting player ${player.nameTag} for TELEPORT_SAFE: ${e.stack || e}`, player.nameTag);
+                logDetails = `Failed to teleport player ${player.nameTag} to ${JSON.stringify(teleportLocation)}. Reason: ${localizedTeleportReason}, Error: ${e.stack || e}`;
+                adminNotifyDetails = getString("common.error.generic") + `: ${e.message || e}`;
                 actionProcessed = false;
             }
             break;
 
         case "flagOnly":
-            logDetails = \`FLAG_ONLY rule processed for check: \${checkType}. No punitive action taken by design. ReasonKey: \${parameters.reasonKey || 'N/A'}\`;
+            logDetails = `FLAG_ONLY rule processed for check: ${checkType}. No punitive action taken by design. ReasonKey: ${parameters.reasonKey || 'N/A'}`;
             actionProcessed = true;
             break;
         default:
-            playerUtils.debugLog(dependencies, \`[AutoModManager] Unknown actionType '\${actionType}' for \${player.nameTag} in _executeAutomodAction.\`, player.nameTag);
+            playerUtils.debugLog(dependencies, `[AutoModManager] Unknown actionType '${actionType}' for ${player.nameTag} in _executeAutomodAction.`, player.nameTag);
             actionProcessed = false;
             break;
     }
 
     if (actionProcessed && logManager?.addLog) {
         logManager.addLog('info', { // Changed to 'info' for successful automod actions. Errors are logged with 'error' type directly.
-            event: \`automod_\${actionType.toLowerCase()}\`, // Standardized event naming
+            event: `automod_${actionType.toLowerCase()}`, // Standardized event naming
             adminName: 'AutoMod', // Consistent adminName
             targetName: player.nameTag,
             duration: durationForLog, // Can be null if not applicable
-            reason: parameters?.reasonKey || \`Automated action for \${checkType}\`,
+            reason: parameters?.reasonKey || `Automated action for ${checkType}`,
             details: logDetails,
             checkType: checkType, // Added for better context in logs
             actionParams: parameters // Log parameters for better diagnostics
@@ -376,9 +376,9 @@ async function _executeAutomodAction(player, pData, actionType, parameters, chec
         // Avoid logging for 'flagOnly' or if the action type itself is unknown (already debug logged)
         const criticalActions = ["warn", "kick", "tempBan", "permBan", "mute", "removeIllegalItem", "teleportSafe"];
         if (criticalActions.includes(actionType)) {
-             playerUtils.debugLog(dependencies, \`AutomodManager: Action '\${actionType}' failed to process correctly for \${player.nameTag}. Details: \${logDetails}\`, player.nameTag);
+             playerUtils.debugLog(dependencies, `AutomodManager: Action '${actionType}' failed to process correctly for ${player.nameTag}. Details: ${logDetails}`, player.nameTag);
              logManager.addLog('warn', { // Use 'warn' as it's a failure of a defined action, not necessarily a system error.
-                event: \`automod_\${actionType.toLowerCase()}_processing_failure\`,
+                event: `automod_${actionType.toLowerCase()}_processing_failure`,
                 targetName: player.nameTag,
                 details: logDetails,
                 checkType: checkType,
@@ -403,7 +403,7 @@ export async function processAutoModActions(player, pData, checkType, dependenci
     if (currentAutomodConfig.automodPerCheckTypeToggles &&
         typeof currentAutomodConfig.automodPerCheckTypeToggles[checkType] === 'boolean' &&
         !currentAutomodConfig.automodPerCheckTypeToggles[checkType]) {
-        playerUtils.debugLog(dependencies, \`AutomodManager: AutoMod for checkType '\${checkType}' on \${player.nameTag} is disabled via per-check toggle.\`, player.nameTag);
+        playerUtils.debugLog(dependencies, `AutomodManager: AutoMod for checkType '${checkType}' on ${player.nameTag} is disabled via per-check toggle.`, player.nameTag);
         return;
     }
 
@@ -444,14 +444,14 @@ export async function processAutoModActions(player, pData, checkType, dependenci
 
     if (bestRuleToApply) {
         if (bestRuleToApply.flagThreshold === checkState.lastActionThreshold && currentFlags === checkState.lastActionThreshold) {
-            playerUtils.debugLog(dependencies, \`AutomodManager: Rule for threshold \${bestRuleToApply.flagThreshold} for \${checkType} on \${player.nameTag} was already the last actioned. Current flags (\${currentFlags}) haven't surpassed it. Skipping.\`, player.nameTag);
+            playerUtils.debugLog(dependencies, `AutomodManager: Rule for threshold ${bestRuleToApply.flagThreshold} for ${checkType} on ${player.nameTag} was already the last actioned. Current flags (${currentFlags}) haven't surpassed it. Skipping.`, player.nameTag);
             return;
         }
 
-        playerUtils.debugLog(dependencies, \`AutomodManager: \${player.nameTag} (flags: \${currentFlags} for \${checkType}) meets threshold \${bestRuleToApply.flagThreshold}. Intended action: \${bestRuleToApply.actionType}\`, player.nameTag);
+        playerUtils.debugLog(dependencies, `AutomodManager: ${player.nameTag} (flags: ${currentFlags} for ${checkType}) meets threshold ${bestRuleToApply.flagThreshold}. Intended action: ${bestRuleToApply.actionType}`, player.nameTag);
 
         if (bestRuleToApply.parameters) {
-            playerUtils.debugLog(dependencies, \`AutomodManager: Action parameters: \${JSON.stringify(bestRuleToApply.parameters)}\`, player.nameTag);
+            playerUtils.debugLog(dependencies, `AutomodManager: Action parameters: ${JSON.stringify(bestRuleToApply.parameters)}`, player.nameTag);
         }
 
         let finalParameters = bestRuleToApply.parameters || {};
@@ -463,9 +463,9 @@ export async function processAutoModActions(player, pData, checkType, dependenci
                     ...finalParameters,
                     itemToRemoveTypeId: itemDetail.itemTypeId,
                 };
-                playerUtils.debugLog(dependencies, \`AutomodManager: Extracted item \${itemDetail.itemTypeId} from pData.lastViolationDetailsMap for REMOVE_ILLEGAL_ITEM action.\`, player.nameTag);
+                playerUtils.debugLog(dependencies, `AutomodManager: Extracted item ${itemDetail.itemTypeId} from pData.lastViolationDetailsMap for REMOVE_ILLEGAL_ITEM action.`, player.nameTag);
             } else {
-                playerUtils.debugLog(dependencies, \`AutomodManager: REMOVE_ILLEGAL_ITEM action for \${checkType} on \${player.nameTag} but no specific itemTypeId found in pData.lastViolationDetailsMap. Action might be ignored or fail in _executeAutomodAction.\`, player.nameTag);
+                playerUtils.debugLog(dependencies, `AutomodManager: REMOVE_ILLEGAL_ITEM action for ${checkType} on ${player.nameTag} but no specific itemTypeId found in pData.lastViolationDetailsMap. Action might be ignored or fail in _executeAutomodAction.`, player.nameTag);
             }
         }
 
@@ -477,7 +477,7 @@ export async function processAutoModActions(player, pData, checkType, dependenci
             pData.isDirtyForSave = true;
 
             if (bestRuleToApply.resetFlagsAfterAction) {
-                playerUtils.debugLog(dependencies, \`AutomodManager: Resetting flags for \${checkType} on \${player.nameTag} as per rule (Threshold: \${bestRuleToApply.flagThreshold}, Action: \${bestRuleToApply.actionType}).\`, player.nameTag);
+                playerUtils.debugLog(dependencies, `AutomodManager: Resetting flags for ${checkType} on ${player.nameTag} as per rule (Threshold: ${bestRuleToApply.flagThreshold}, Action: ${bestRuleToApply.actionType}).`, player.nameTag);
                 if (pData.flags?.[checkType]) {
                     pData.flags[checkType].count = 0;
                 }

--- a/AntiCheatsBP/scripts/core/languages/en_US.js
+++ b/AntiCheatsBP/scripts/core/languages/en_US.js
@@ -64,9 +64,9 @@ export const translations = {
             description: "Accepts an incoming TPA request.",
             usage: "§cUsage: {prefix}tpaccept [playerName]",
             error_noPending: "§cYou have no pending TPA requests.",
-            error_noRequestFrom": "§cNo pending TPA request found from \"{playerName}\".",
-            error_pendingFromList": "§7Pending requests are from: {playerList}",
-            error_couldNotFind": "§cCould not find a suitable TPA request to accept. Type {prefix}tpastatus to see your requests.",
+            error_noRequestFrom: "§cNo pending TPA request found from \"{playerName}\".",
+            error_pendingFromList: "§7Pending requests are from: {playerList}",
+            error_couldNotFind: "§cCould not find a suitable TPA request to accept. Type {prefix}tpastatus to see your requests.",
             success: "§aAccepted TPA request from \"{playerName}\". Teleport will occur in {warmupSeconds} seconds if the teleporting player avoids damage and stays online.",
             fail: "§cCould not accept TPA request from \"{playerName}\". It might have expired or been cancelled.",
             teleportWarmupCancelled: "§cTeleport cancelled for TPA request from {requesterName} to {targetName} because {reason}.",
@@ -84,7 +84,7 @@ export const translations = {
             success_specific: "§aSuccessfully cancelled/declined TPA request involving \"{playerName}\".",
             success_all: "§aCancelled/declined {count} TPA request(s).",
             error_noRequests: "§cYou have no active TPA requests to cancel or decline.",
-            error_noSpecificRequest": "§cNo active or pending TPA request found with \"{playerName}\" that can be cancelled.",
+            error_noSpecificRequest: "§cNo active or pending TPA request found with \"{playerName}\" that can be cancelled.",
             error_noneCancellable: "§cNo active requests were found in a state that could be cancelled/declined.",
             notifyOther_cancelled: "§eTPA request involving \"{otherPlayerName}\" was cancelled by {cancellingPlayerName}.",
         },
@@ -95,7 +95,7 @@ export const translations = {
             nowDisabled: "§cYou are no longer accepting TPA requests.",
             nowDisabledDeclined: "§e{count} pending incoming TPA request(s) were automatically declined.",
             current_enabled: "§aYou are currently accepting TPA requests.",
-            current_disabled": "§cYou are currently not accepting TPA requests.",
+            current_disabled: "§cYou are currently not accepting TPA requests.",
             error_invalidOption: "§cInvalid option. Usage: {prefix}tpastatus [on|off|status]",
             notifyRequester_declined: "§e{targetPlayerName} is no longer accepting TPA requests; your request was automatically declined.",
         },
@@ -104,7 +104,7 @@ export const translations = {
             specific_syntax: "§eSyntax:§r {prefix}{commandName} {syntaxArgs}",
             specific_description: "§bDescription:§r {description}",
             specific_permission: "§7Permission: {permLevelName} (Level {permissionLevel})",
-            specific_notFoundOrNoPermission": "§cCommand \"{commandName}\" not found or you do not have permission to view its details. Type {prefix}help for a list of available commands.",
+            specific_notFoundOrNoPermission: "§cCommand \"{commandName}\" not found or you do not have permission to view its details. Type {prefix}help for a list of available commands.",
             error_unknownCommand: "§cUnknown command: \"{commandName}\". Type {prefix}help for a list of available commands.",
             list_header: "§l§bAvailable Commands (prefix: {prefix}):§r",
             list_noCommandsAvailable: "§7No commands available to you at this time.",
@@ -127,7 +127,7 @@ export const translations = {
         },
         copyinv: {
             description: "Copies another player's inventory to your own.",
-            error_playerLookupUnavailable": "§cCommand error: Player lookup utility not available.",
+            error_playerLookupUnavailable: "§cCommand error: Player lookup utility not available.",
             usage: "§cUsage: {prefix}copyinv <playername>",
             error_selfCopy: "§cYou cannot copy your own inventory.",
             error_inventoryAccess: "§cCould not access inventories.",
@@ -162,7 +162,7 @@ export const translations = {
             mutedYes: "§fMuted: §cYes (Expires: {expiryDate}, Reason: {reason})",
             mutedNo: "§fMuted: §aNo",
             bannedYes: "§fBanned: §cYes (Expires: {expiryDate}, Reason: {reason})",
-            bannedNo": "§fBanned: §aNo",
+            bannedNo: "§fBanned: §aNo",
             noData: "§7No AntiCheat data found for this player (they might not have triggered any checks or joined recently).",
         },
         testnotify: {
@@ -183,7 +183,7 @@ export const translations = {
             description: "Shows a detailed list of warnings/flags for a player.",
             usage: "§cUsage: {prefix}warnings <playername>",
             header: "§e--- Warnings for {playerName} ---",
-            individualFlagsHeader": "§eIndividual Flags:",
+            individualFlagsHeader: "§eIndividual Flags:",
             noData: "§cNo warning data found for {playerName}.",
         },
         listwatched: {
@@ -200,7 +200,7 @@ export const translations = {
         },
         inventoryMod: {
             details_switchAndUseSameTick: "Item used in the same tick as hotbar slot change",
-            details_movedWhileLocked": "Inventory item moved/changed (slot {slotNum}) while {action}",
+            details_movedWhileLocked: "Inventory item moved/changed (slot {slotNum}) while {action}",
             action_usingConsumable: "using consumable",
             action_chargingBow: "charging bow",
         },
@@ -209,7 +209,7 @@ export const translations = {
             reason_staticPitch: "Static Pitch",
             reason_staticYaw: "Static Yaw",
             reason_flatHorizontal: "Flat Horizontal Pitch Range",
-            reason_flatDownward": "Flat Downward Pitch Range",
+            reason_flatDownward: "Flat Downward Pitch Range",
         },
         nameSpoof: {
             reason_lengthExceeded: "NameTag length limit exceeded ({currentLength}/{maxLength})",
@@ -228,7 +228,7 @@ export const translations = {
         noSlow: {
             action_eatingDrinking: "Eating/Drinking",
             action_chargingBow: "Charging Bow",
-            action_usingShield": "Using Shield",
+            action_usingShield: "Using Shield",
             action_sneaking: "Sneaking",
         },
     },
@@ -236,8 +236,8 @@ export const translations = {
         ban_kickHeader: "§cYou are banned from this server.",
         ban_kickBannedBy: "§fBanned by: §e{adminName}",
         ban_kickReason: "§fReason: §e{reason}",
-        ban_kickExpires": "§fExpires: §e{expiryDate}",
-        ban_kickDiscord": "§fDiscord: §b{discordLink}",
+        ban_kickExpires: "§fExpires: §e{expiryDate}",
+        ban_kickDiscord: "§fDiscord: §b{discordLink}",
         mute_defaultReason: "Muted by system.",
         ban_defaultReason: "Banned by system.",
     },
@@ -248,7 +248,7 @@ export const translations = {
         action_permbanDefaultReason: "Permanently banned by AutoMod for severe rule violations.",
         action_muteDefaultReason: "Muted by AutoMod.",
         action_freezeDefaultReason: "Player frozen by AutoMod due to rule violation.",
-        action_teleportDefaultReason": "AutoMod: You have been teleported to a safe location.", // Existing typo noted, not fixing in this pass.
+        action_teleportDefaultReason: "AutoMod: You have been teleported to a safe location.", // Existing typo noted, not fixing in this pass.
         "automod.chat.contentrepeat.warn1": "AutoMod: Please avoid repeating the same message content.",
         "automod.chat.contentrepeat.mute1": "AutoMod: Muted for 5 minutes for repeating message content.",
         "automod.chat.contentrepeat.mute2": "AutoMod: Muted for 30 minutes for persistent message content repetition.",
@@ -268,32 +268,32 @@ export const translations = {
         kickMessage_common_reason: "Reason: {reason}",
         kickMessage_common_duration: "Duration: {duration}",
         adminNotify_actionReport: "{basePrefix} Action: {actionType} on {playerName} for {checkType}. Reason: {reason}{details}",
-        adminNotify_basePrefix": "§7[§cAutoMod§7]", // Existing typo noted
+        adminNotify_basePrefix: "§7[§cAutoMod§7]", // Existing typo noted
         adminNotify_details_duration: ". Duration: {duration}",
-        adminNotify_details_item": ". Item: {item}", // Existing typo noted
-        adminNotify_details_teleport": "Teleported to: X:{x} Y:{y} Z:{z}", // Existing typo noted
+        adminNotify_details_item: ". Item: {item}", // Existing typo noted
+        adminNotify_details_teleport: "Teleported to: X:{x} Y:{y} Z:{z}", // Existing typo noted
         default_itemRemoved: "AutoMod removed {quantity}x {itemTypeId} from your inventory.",
     },
     tpaManager: { // Keys starting with "tpa.manager."
-        error_targetOfflineOnAccept": "§c{offlinePlayerName} is no longer online. TPA request cancelled.",
+        error_targetOfflineOnAccept: "§c{offlinePlayerName} is no longer online. TPA request cancelled.",
         warmupMessage: "§eTeleporting in {warmupSeconds} seconds. Do not move or take damage.",
         requester_accepted: "§aYour TPA request to \"{targetPlayerName}\" has been accepted. {warmupMessage}",
         target_acceptedByRequester: "§a\"{requesterPlayerName}\" accepted your TPA request. {warmupMessage}",
-        target_acceptedFromRequester": "§aYou accepted the TPA request from \"{requesterPlayerName}\". They will teleport in {warmupSeconds}s.",
+        target_acceptedFromRequester: "§aYou accepted the TPA request from \"{requesterPlayerName}\". They will teleport in {warmupSeconds}s.",
         requester_acceptedHere: "§a\"{targetPlayerName}\" accepted your TPA Here request. They will teleport in {warmupSeconds}s.",
-        error_teleportTargetOffline": "§cTeleport cancelled: {offlinePlayerName} logged off.",
-        teleport_successToTarget": "§aTeleported successfully to {targetPlayerName}.",
-        teleport_successTargetNotified": "§a{requesterPlayerName} has teleported to you.",
-        teleport_successToRequester": "§aTeleported successfully to {requesterPlayerName}.",
-        teleport_successRequesterNotified": "§a{targetPlayerName} has teleported to you.",
-        error_teleportGenericErrorToRequester": "§cAn error occurred during teleportation. Please try again.",
-        error_teleportGenericErrorToTarget": "§cAn error occurred during a TPA teleportation involving {otherPlayerName}.",
-        decline_requesterNotified": "§c\"{targetPlayerName}\" declined your TPA request.",
-        decline_targetNotified": "§cYou declined the TPA request from \"{requesterPlayerName}\".",
-        decline_otherCancelledRequester": "§cTPA request involving \"{targetPlayerName}\" was cancelled.",
-        decline_otherCancelledTarget": "§cTPA request involving \"{requesterPlayerName}\" was cancelled.",
-        expired_requesterNotified": "§cYour TPA request to \"{targetName}\" has expired.",
-        expired_targetNotified": "§cThe TPA request from \"{requesterName}\" has expired.",
+        error_teleportTargetOffline: "§cTeleport cancelled: {offlinePlayerName} logged off.",
+        teleport_successToTarget: "§aTeleported successfully to {targetPlayerName}.",
+        teleport_successTargetNotified: "§a{requesterPlayerName} has teleported to you.",
+        teleport_successToRequester: "§aTeleported successfully to {requesterPlayerName}.",
+        teleport_successRequesterNotified: "§a{targetPlayerName} has teleported to you.",
+        error_teleportGenericErrorToRequester: "§cAn error occurred during teleportation. Please try again.",
+        error_teleportGenericErrorToTarget: "§cAn error occurred during a TPA teleportation involving {otherPlayerName}.",
+        decline_requesterNotified: "§c\"{targetPlayerName}\" declined your TPA request.",
+        decline_targetNotified: "§cYou declined the TPA request from \"{requesterPlayerName}\".",
+        decline_otherCancelledRequester: "§cTPA request involving \"{targetPlayerName}\" was cancelled.",
+        decline_otherCancelledTarget: "§cTPA request involving \"{requesterPlayerName}\" was cancelled.",
+        expired_requesterNotified: "§cYour TPA request to \"{targetName}\" has expired.",
+        expired_targetNotified: "§cThe TPA request from \"{requesterName}\" has expired.",
     },
     profiles: { // Keys starting with "profile."
         movementFlyHover: { // Key renamed from example_fly_hover
@@ -410,7 +410,7 @@ export const translations = {
         },
         player_antigmc: {
             flagReason: "System detected unauthorized Creative Mode.",
-            notifyMessage": "§cAC: {playerName} detected in unauthorized Creative Mode! Switched to {switchToMode}: {autoSwitched}",
+            notifyMessage: "§cAC: {playerName} detected in unauthorized Creative Mode! Switched to {switchToMode}: {autoSwitched}",
         },
         player_inventory_mod: {
             flagReason: "System detected suspicious inventory/hotbar manipulation ({reasonDetail}).",
@@ -512,13 +512,13 @@ export const translations = {
         dimensionLock_teleportMessage: "§cYou cannot enter {lockedDimensionName} as it is currently locked.",
         chat_error_muted: "§cYou are currently muted and cannot send messages.",
         chat_error_combatCooldown: "§cYou cannot chat for {seconds} seconds after combat.",
-        chat_error_itemUse": "§cYou cannot chat while {itemUseState}.",
+        chat_error_itemUse: "§cYou cannot chat while {itemUseState}.",
     },
     ui: {
         panel_error_uiManagerUnavailable: "§cError: The UI Panel manager is currently unavailable.", // From command.panel...
         systemInfo: { // From ui.systemInfo...
             label_currentTick: "Current Server Tick:",
-            label_worldTime": "World Time (ticks):",
+            label_worldTime: "World Time (ticks):",
             label_defaultServerLanguage: "Default Server Language:",
             entry: {
                 acVersion: "AntiCheat Version: {version}",

--- a/AntiCheatsBP/scripts/core/playerDataManager.js
+++ b/AntiCheatsBP/scripts/core/playerDataManager.js
@@ -505,7 +505,7 @@ export async function addFlag(player, flagType, reasonMessage, detailsForNotify 
             quantityFound: detailsForNotify.quantityFound || 0,
             timestamp: Date.now()
         };
-        playerUtils.debugLog(dependencies, \`PDM:addFlag: Stored violation details for \${flagType} on \${player.nameTag}: \${JSON.stringify(pData.lastViolationDetailsMap[flagType])}\`, player.nameTag);
+        playerUtils.debugLog(dependencies, `PDM:addFlag: Stored violation details for ${flagType} on ${player.nameTag}: ${JSON.stringify(pData.lastViolationDetailsMap[flagType])}`, player.nameTag);
     }
 
     pData.isDirtyForSave = true;


### PR DESCRIPTION
This commit addresses previously missed and newly identified instances of malformed object keys in AntiCheatsBP/scripts/core/languages/en_US.js. The primary issue was unquoted identifiers having a stray trailing quotation mark (e.g., `keyName": "value"`).

Corrections include:
- Keys within the `playerData` object (e.g., `ban_kickExpires`, `ban_kickDiscord`).
- Multiple keys within the `tpaManager` object (e.g., `error_targetOfflineOnAccept`, `teleport_successTargetNotified`).
- A general sweep ensures all such malformed keys are now standard identifiers.

This should resolve the persistent SyntaxError: expecting '}' issues related to this file and ensure it is correctly parsed.