### PR TITLE
Fix: Pass dependencies to cleanupActivePlayerData

### DIFF
--- a/AntiCheatsBP/scripts/main.js
+++ b/AntiCheatsBP/scripts/main.js
@@ -251,7 +251,7 @@ mc.system.runInterval(async () => {
     }
 
     const allPlayers = mc.world.getAllPlayers();
-    // playerDataManager.cleanupActivePlayerData(allPlayers); // This line seems to be missing its dependencies argument
+    playerDataManager.cleanupActivePlayerData(allPlayers, tickDependencies);
 
     for (const player of allPlayers) {
         const pData = await playerDataManager.ensurePlayerDataInitialized(player, currentTick, tickDependencies);


### PR DESCRIPTION
The cleanupActivePlayerData function in playerDataManager.js requires a dependencies object, which was not being passed in the main tick loop in main.js. This commit adds the missing 'tickDependencies' argument to the function call.

This resolves a runtime error that would occur when the cleanup function was invoked.