### PR TITLE
Fix: Correct syntax error in worldborder.js

### DIFF
--- a/AntiCheatsBP/scripts/commands/worldborder.js
+++ b/AntiCheatsBP/scripts/commands/worldborder.js
@@ -16,7 +16,7 @@ export const definition = {
 };
 
 export async function execute(player, args, dependencies) {
-    const { playerUtils, logManager, config, configModule, worldBorderManager, uiManager, getString } = dependencies;
+    const { playerUtils, logManager, config, configModule, worldBorderManager, uiManager } = dependencies;
     const subCommand = args.shift()?.toLowerCase();
     const cmdPrefix = config.prefix;
 


### PR DESCRIPTION
Removed undefined getString from worldborder.js.
Reviewed all JavaScript files for syntax errors. No other errors were found.