### PR TITLE
Remove remaining localization artifacts

### DIFF
--- a/AntiCheatsBP/scripts/commands/commandRegistry.js
+++ b/AntiCheatsBP/scripts/commands/commandRegistry.js
@@ -29,7 +29,6 @@ import * as panelCmd from './panel.js';
 import * as removerankCmd from './removerank.js';
 import * as resetflagsCmd from './resetflags.js';
 import * as rulesCmd from './rules.js';
-// import * as setlangCmd from './setlang.js'; // Localization removed
 import * as testnotifyCmd from './testnotify.js';
 import * as tpCmd from './tp.js';
 import * as tpaCmd from './tpa.js';

--- a/AntiCheatsBP/scripts/config.js
+++ b/AntiCheatsBP/scripts/config.js
@@ -323,7 +323,6 @@ export const commandSettings = {
     netherlock: { enabled: false }, // Dimension lock commands might be complex
     endlock: { enabled: false },
     worldborder: { enabled: true }, // Depends on enableWorldBorderSystem
-    setlang: { enabled: false }, // Multi-language support removed
     addrank: { enabled: true }, // Depends on rank system
     removerank: { enabled: true }, // Depends on rank system
     listranks: { enabled: true }, // Depends on rank system


### PR DESCRIPTION
Removes commented-out code related to a previously disabled localization feature (setlang command).