### PR TITLE
Fix: Correct variable scope in uiManager.js catch block

### DIFF
--- a/AntiCheatsBP/scripts/core/uiManager.js
+++ b/AntiCheatsBP/scripts/core/uiManager.js
@@ -352,7 +352,7 @@ showAdminPanelMain = async function (player, playerDataManager, config, dependen
     } catch (error) {
         depPlayerUtils.debugLog(`Error in showAdminPanelMain: ${error.stack || error}`, player.nameTag, dependencies);
         logManager.addLog({ adminName: player.nameTag, actionType: 'error', context: 'uiManager.showAdminPanelMain', details: `Error: ${error.message}` }, dependencies);
-        adminPlayer.sendMessage(getString('ui.adminPanel.error.generic'));
+        player.sendMessage(getString('ui.adminPanel.error.generic'));
     }
 };
 


### PR DESCRIPTION
Changed `adminPlayer.sendMessage` to `player.sendMessage` in the catch block of the `showAdminPanelMain` function. This resolves a potential runtime error where `adminPlayer` would be undefined in that specific scope, preventing an error message from being sent to the player if an error occurred while trying to show the admin panel.