### PR TITLE
Fix syntax error in worldborder.js

### DIFF
--- a/AntiCheatsBP/scripts/commands/worldborder.js
+++ b/AntiCheatsBP/scripts/commands/worldborder.js
@@ -77,7 +77,7 @@ export async function execute(player, args, dependencies) {
         default:
             playerUtils.warnPlayer(player, `§cInvalid subcommand '${subCommand}'. Use ${cmdPrefix}wb help.`);
     }
-} // This closing brace was missing
+}
 
 function formatDurationBrief(ms) {
     if (ms <= 0) return '0s';


### PR DESCRIPTION
- Added missing closing brace to the execute function in AntiCheatsBP/scripts/commands/worldborder.js.