### PR TITLE
Fix: Correct configModule access in worldborder command

### DIFF
--- a/AntiCheatsBP/scripts/commands/worldborder.js
+++ b/AntiCheatsBP/scripts/commands/worldborder.js
@@ -499,7 +499,7 @@ async function handleResizeResumeCommand(player, args, dependencies) {
 }
 
 async function handleSetGlobalParticleCommand(player, args, dependencies) {
-    const { playerUtils, logManager, configModule, config: currentRunTimeConfig } = dependencies;
+    const { playerUtils, logManager, editableConfig: configModule, config: currentRunTimeConfig } = dependencies;
     const prefix = currentRunTimeConfig.prefix;
 
     if (args.length < 1) {


### PR DESCRIPTION
The `handleSetGlobalParticleCommand` in `worldborder.js` was attempting to destructure `configModule` directly from dependencies. However, `main.js` provides the full configuration module as `dependencies.editableConfig`.

This commit updates `worldborder.js` to correctly destructure `editableConfig` and alias it to `configModule` within the `handleSetGlobalParticleCommand` function, resolving a runtime TypeError that would occur when using the `!wb setglobalparticle` subcommand.