### PR TITLE
Fix: Standardize combatMultiTargetAura key

### DIFF
--- a/AntiCheatsBP/scripts/core/playerDataManager.js
+++ b/AntiCheatsBP/scripts/core/playerDataManager.js
@@ -231,7 +231,7 @@ export function initializeDefaultPlayerData(player, currentTick, dependencies) {
             combatViewSnapPitch: { count: 0, lastDetectionTime: 0 }, // Standardized
             combatViewSnapYaw: { count: 0, lastDetectionTime: 0 }, // Standardized
             combatInvalidPitch: { count: 0, lastDetectionTime: 0 },
-            combatMultiTargetAura: { count: 0, lastDetectionTime: 0 }, // Standardized
+            combatMultitargetAura: { count: 0, lastDetectionTime: 0 }, // Standardized
             combatAttackWhileSleeping: { count: 0, lastDetectionTime: 0 },
             combatAttackWhileConsuming: { count: 0, lastDetectionTime: 0 },
             combatAttackWhileBowCharging: { count: 0, lastDetectionTime: 0 },


### PR DESCRIPTION
Standardized the casing of the `combatMultiTargetAura` flag key in `playerDataManager.js` to `combatMultitargetAura` to ensure consistency with its usage in `actionProfiles.js`.

Reviewed all JavaScript files for syntax errors; no major syntax issues were found. A minor logical placement of `pData.lastCombatInteractionTime` in `eventHandlers.js` was noted but the line was not present in the current version of the file.