### PR TITLE
Refactor: Initial cleanup of comments and whitespace

### DIFF
--- a/AntiCheatsBP/scripts/core/eventHandlers.js
+++ b/AntiCheatsBP/scripts/core/eventHandlers.js
@@ -1,7 +1,5 @@
 /**
  * @file Centralized handlers for various Minecraft Server API events.
- * These handlers process event data, interact with managers (PlayerData, Action, Log),
- * and delegate to specific check functions for cheat detection and system responses.
  */
 import * as mc from '@minecraft/server';
 import { getExpectedBreakTicks, isNetherLocked, isEndLocked } from '../utils/index.js';
@@ -9,8 +7,8 @@ import { formatSessionDuration } from '../utils/playerUtils.js';
 
 /**
  * Handles player leave events.
- * @param {import('@minecraft/server').PlayerLeaveBeforeEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * @param {import('@minecraft/server').PlayerLeaveBeforeEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handlePlayerLeave(eventData, dependencies) {
     const { playerDataManager, playerUtils, config: currentConfig, logManager, getString } = dependencies;
@@ -95,8 +93,8 @@ export async function handlePlayerLeave(eventData, dependencies) {
 
 /**
  * Handles player spawn events (initial join and respawn).
- * @param {import('@minecraft/server').PlayerSpawnAfterEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * @param {import('@minecraft/server').PlayerSpawnAfterEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handlePlayerSpawn(eventData, dependencies) {
     const { player, initialSpawn } = eventData;
@@ -212,9 +210,9 @@ export async function handlePlayerSpawn(eventData, dependencies) {
 }
 
 /**
- * Handles piston activation events for AntiGrief purposes (e.g., lag machine detection).
- * @param {import('@minecraft/server').PistonActivateAfterEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * Handles piston activation events for AntiGrief (e.g., lag machine detection).
+ * @param {import('@minecraft/server').PistonActivateAfterEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handlePistonActivate_AntiGrief(eventData, dependencies) {
     const { config, playerUtils, checks } = dependencies;
@@ -238,9 +236,9 @@ export async function handlePistonActivate_AntiGrief(eventData, dependencies) {
 }
 
 /**
- * Handles entity spawn events for AntiGrief purposes (e.g., Wither, Golem spam).
- * @param {import('@minecraft/server').EntitySpawnAfterEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * Handles entity spawn events for AntiGrief (e.g., Wither, Golem spam).
+ * @param {import('@minecraft/server').EntitySpawnAfterEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handleEntitySpawnEvent_AntiGrief(eventData, dependencies) {
     const { config, playerUtils, actionManager, playerDataManager, checks } = dependencies;
@@ -283,8 +281,8 @@ export async function handleEntitySpawnEvent_AntiGrief(eventData, dependencies) 
 
 /**
  * Handles player block placement before events for AntiGrief (e.g., TNT).
- * @param {import('@minecraft/server').PlayerPlaceBlockBeforeEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * @param {import('@minecraft/server').PlayerPlaceBlockBeforeEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handlePlayerPlaceBlockBeforeEvent_AntiGrief(eventData, dependencies) {
     const { config, playerUtils, actionManager, rankManager, getString, permissionLevels } = dependencies;
@@ -313,8 +311,8 @@ export async function handlePlayerPlaceBlockBeforeEvent_AntiGrief(eventData, dep
 
 /**
  * Handles entity death events for cosmetic death effects.
- * @param {import('@minecraft/server').EntityDieAfterEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * @param {import('@minecraft/server').EntityDieAfterEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handleEntityDieForDeathEffects(eventData, dependencies) {
     const { config: currentConfig, playerUtils } = dependencies;
@@ -345,12 +343,12 @@ export async function handleEntityDieForDeathEffects(eventData, dependencies) {
 }
 
 /**
- * Handles entity hurt events, primarily for combat-related checks and state updates.
- * @param {import('@minecraft/server').EntityHurtAfterEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * Handles entity hurt events for combat checks and state updates.
+ * @param {import('@minecraft/server').EntityHurtAfterEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handleEntityHurt(eventData, dependencies) {
-    const { playerDataManager, checks, config, currentTick, playerUtils } = dependencies; // Removed actionManager as it's called by checks
+    const { playerDataManager, checks, config, currentTick, playerUtils } = dependencies;
     const { hurtEntity, damageSource, damagingEntity: directDamagingEntity } = eventData;
 
     if (hurtEntity?.typeId === 'minecraft:player') {
@@ -387,14 +385,12 @@ export async function handleEntityHurt(eventData, dependencies) {
             }
         }
     }
-    // General combat event processing if defined
-    // if (checks.processCombatEvent) await checks.processCombatEvent(eventData, dependencies);
 }
 
 /**
- * Handles player death events, e.g., for logging or sending death coordinates.
- * @param {import('@minecraft/server').PlayerDeathAfterEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * Handles player death events (e.g., logging, death coordinates).
+ * @param {import('@minecraft/server').PlayerDeathAfterEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handlePlayerDeath(eventData, dependencies) {
     const { player } = eventData;
@@ -431,8 +427,8 @@ export async function handlePlayerDeath(eventData, dependencies) {
 }
 
 /**
- * Subscribes to entityHurt events specifically for combat log detection.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * Subscribes to entityHurt events for combat log detection.
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export function subscribeToCombatLogEvents(dependencies) {
     const { config, playerDataManager } = dependencies;
@@ -456,9 +452,9 @@ export function subscribeToCombatLogEvents(dependencies) {
 }
 
 /**
- * Handles player block break before events, primarily for InstaBreak timing setup.
- * @param {import('@minecraft/server').PlayerBreakBlockBeforeEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * Handles player block break before events (e.g., InstaBreak timing).
+ * @param {import('@minecraft/server').PlayerBreakBlockBeforeEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handlePlayerBreakBlockBeforeEvent(eventData, dependencies) {
     const { checks, config, playerDataManager, currentTick } = dependencies;
@@ -483,16 +479,12 @@ export async function handlePlayerBreakBlockBeforeEvent(eventData, dependencies)
         pData.isDirtyForSave = true;
     }
 
-    // Assuming checkNukerRaycast is part of checks and enabled
-    // if (checks.checkNukerRaycast && config.enableNukerCheck) {
-    // await checks.checkNukerRaycast(player, block, dependencies);
-    // }
 }
 
 /**
- * Handles player block break after events for checks like XRay and InstaBreak (speed part).
- * @param {import('@minecraft/server').PlayerBreakBlockAfterEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * Handles player block break after events (e.g., XRay, InstaBreak speed).
+ * @param {import('@minecraft/server').PlayerBreakBlockAfterEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handlePlayerBreakBlockAfterEvent(eventData, dependencies) {
     const { config, playerDataManager, checks } = dependencies;
@@ -524,8 +516,8 @@ export async function handlePlayerBreakBlockAfterEvent(eventData, dependencies) 
 
 /**
  * Handles item use events.
- * @param {import('@minecraft/server').ItemUseBeforeEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * @param {import('@minecraft/server').ItemUseBeforeEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handleItemUse(eventData, dependencies) {
     const { checks, config, getString, playerUtils, playerDataManager } = dependencies;
@@ -559,8 +551,7 @@ export async function handleItemUse(eventData, dependencies) {
     if (config.preventedItemUses && config.preventedItemUses.includes(itemStack.typeId)) {
         playerUtils.warnPlayer(player, getString('antigrief.itemUseDenied', { item: itemStack.typeId }));
         eventData.cancel = true;
-        // Potentially add a flag or log this action via actionManager
-        // actionManager.executeCheckAction('worldIllegalItemUse', player, { itemTypeId: itemStack.typeId, action: 'use' }, dependencies);
+        // TODO: Consider adding actionManager.executeCheckAction('worldIllegalItemUse', player, { itemTypeId: itemStack.typeId, action: 'use' }, dependencies);
         return;
     }
 
@@ -570,8 +561,8 @@ export async function handleItemUse(eventData, dependencies) {
 
 /**
  * Handles item use on block events.
- * @param {import('@minecraft/server').ItemUseOnBeforeEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * @param {import('@minecraft/server').ItemUseOnBeforeEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handleItemUseOn(eventData, dependencies) {
     const { checks, config, playerDataManager } = dependencies;
@@ -581,25 +572,20 @@ export async function handleItemUseOn(eventData, dependencies) {
     const pData = playerDataManager.getPlayerData(player.id);
     if (!pData) return;
 
-    // Assuming checkIllegalItemUseOnBlock is for specific interactions, not general item bans
-    // if (checks.checkIllegalItemUseOnBlock && config.enableIllegalItemUseOnBlockCheck) {
-    //     await checks.checkIllegalItemUseOnBlock(player, itemStack, block, dependencies);
-    //     if (eventData.cancel) return;
-    // }
+    // IllegalItemUseOnBlock check could be added here if specific rules are needed beyond general item bans.
 
     if (checks.checkAirPlace && config.enableAirPlaceCheck) {
-        // checkAirPlace is usually for PlayerPlaceBlockBeforeEvent. If it's also for ItemUseOn, ensure logic matches.
-        // For now, assuming it's primarily for block placement.
+        // AirPlace check might be relevant here if item use on air is considered.
+        // Currently, it's more tied to block placement events.
     }
 
     if (itemStack.typeId === 'minecraft:bow' && config.enableChatDuringItemUseCheck) {
         if (pData) { pData.isChargingBow = true; pData.isDirtyForSave = true; }
     }
     if (config.preventedItemUsesOn && config.preventedItemUsesOn.includes(itemStack.typeId)) {
-        // Similar to handleItemUse, but for itemUseOn context
         dependencies.playerUtils.warnPlayer(player, dependencies.getString('antigrief.itemUseDenied', {item: itemStack.typeId}));
         eventData.cancel = true;
-        // actionManager.executeCheckAction('worldIllegalItemUse', player, { itemTypeId: itemStack.typeId, action: 'useon', targetBlock: block.typeId }, dependencies);
+        // TODO: Consider adding actionManager.executeCheckAction('worldIllegalItemUse', player, { itemTypeId: itemStack.typeId, action: 'useon', targetBlock: block.typeId }, dependencies);
         return;
     }
 
@@ -609,11 +595,11 @@ export async function handleItemUseOn(eventData, dependencies) {
 
 /**
  * Handles player inventory item change events.
- * @param {import('@minecraft/server').Player} player - The player whose inventory changed.
- * @param {import('@minecraft/server').ItemStack | undefined} newItem - The new item stack in the slot.
- * @param {import('@minecraft/server').ItemStack | undefined} oldItem - The old item stack that was in the slot.
- * @param {string} slotName - The name/identifier of the slot that changed.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * @param {import('@minecraft/server').Player} player
+ * @param {import('@minecraft/server').ItemStack | undefined} newItem
+ * @param {import('@minecraft/server').ItemStack | undefined} oldItem
+ * @param {string} slotName
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handleInventoryItemChange(player, newItem, oldItem, slotName, dependencies) {
     const { checks, config, playerDataManager } = dependencies;
@@ -627,17 +613,15 @@ export async function handleInventoryItemChange(player, newItem, oldItem, slotNa
         await checks.checkInventoryMoveWhileActionLocked(player, pData, dependencies, inventoryChangeData);
     }
 
-    // This check might be too broad here if not careful, could cause performance issues.
-    // Typically, illegal item checks are done on attempted use/place.
-    // if (checks.checkIllegalItems && config.enableIllegalItemCheck && newItem) {
-    //     await checks.checkIllegalItems(player, newItem, { source: player, cancel: false }, 'inventory_change', pData, dependencies);
-    // }
+    // Illegal item checks on inventory change can be intensive; typically handled at use/place.
+    // If specific items need to be checked upon entering inventory, that logic could be added here,
+    // but it's generally less common than event-driven checks.
 }
 
 /**
  * Handles player block placement before events (for checks and AntiGrief).
- * @param {import('@minecraft/server').PlayerPlaceBlockBeforeEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * @param {import('@minecraft/server').PlayerPlaceBlockBeforeEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handlePlayerPlaceBlockBefore(eventData, dependencies) {
     const { checks, config, playerDataManager } = dependencies;
@@ -647,10 +631,7 @@ export async function handlePlayerPlaceBlockBefore(eventData, dependencies) {
     const pData = playerDataManager.getPlayerData(player.id);
     if (!pData) return;
 
-    // if (checks.checkBuildingRestrictions && config.enableBuildingRestrictionCheck) {
-    //     await checks.checkBuildingRestrictions(player, block, itemStack, dependencies);
-    //     if (eventData.cancel) return;
-    // }
+    // Building restriction checks could be added here if needed.
     if (checks.checkAirPlace && config.enableAirPlaceCheck) {
         await checks.checkAirPlace(player, pData, dependencies, eventData);
         if (eventData.cancel) return;
@@ -660,10 +641,10 @@ export async function handlePlayerPlaceBlockBefore(eventData, dependencies) {
 
 /**
  * Internal helper to process effects and checks after a block is placed.
- * @param {import('@minecraft/server').Player} player - The player.
- * @param {import('../types.js').PlayerAntiCheatData} pData - Player's AC data.
- * @param {import('@minecraft/server').Block} block - The block that was placed.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies.
+ * @param {import('@minecraft/server').Player} player
+ * @param {import('../types.js').PlayerAntiCheatData} pData
+ * @param {import('@minecraft/server').Block} block
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 async function _processPlayerPlaceBlockAfterEffects(player, pData, block, dependencies) {
     const { config, playerUtils, checks, currentTick } = dependencies;
@@ -693,8 +674,8 @@ async function _processPlayerPlaceBlockAfterEffects(player, pData, block, depend
 
 /**
  * Handles player block placement after events.
- * @param {import('@minecraft/server').PlayerPlaceBlockAfterEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * @param {import('@minecraft/server').PlayerPlaceBlockAfterEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handlePlayerPlaceBlockAfterEvent(eventData, dependencies) {
     const { playerDataManager } = dependencies;
@@ -710,9 +691,8 @@ export async function handlePlayerPlaceBlockAfterEvent(eventData, dependencies) 
 
 /**
  * Handles chat messages before they are sent, dispatching to chatProcessor.
- * This is the primary entry point for chat-related checks if not a command.
- * @param {import('@minecraft/server').ChatSendBeforeEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * @param {import('@minecraft/server').ChatSendBeforeEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handleBeforeChatSend(eventData, dependencies) {
     const { playerDataManager, config, playerUtils, getString } = dependencies;
@@ -727,11 +707,11 @@ export async function handleBeforeChatSend(eventData, dependencies) {
         return;
     }
 
-    // Command handling is now done in main.js before this general chat handler is called.
-    // This function will only proceed if it's not a command.
+    // This function processes non-command chat messages.
+    // Command handling is managed upstream in main.js.
 
     if (!dependencies.chatProcessor || typeof dependencies.chatProcessor.processChatMessage !== 'function') {
-        console.warn('[AntiCheat] handleBeforeChatSend: chatProcessor.processChatMessage is not available in dependencies. Chat will not be processed.');
+        console.warn('[AntiCheat] handleBeforeChatSend: chatProcessor.processChatMessage is not available. Chat will not be processed.');
         playerUtils.warnPlayer(player, getString('error.chatProcessingUnavailable'));
         eventData.cancel = true;
         return;
@@ -741,9 +721,9 @@ export async function handleBeforeChatSend(eventData, dependencies) {
 }
 
 /**
- * Handles player dimension change after events, primarily for dimension lock enforcement.
- * @param {import('@minecraft/server').PlayerDimensionChangeAfterEvent} eventData - The event data.
- * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
+ * Handles player dimension change after events (e.g., dimension lock enforcement).
+ * @param {import('@minecraft/server').PlayerDimensionChangeAfterEvent} eventData
+ * @param {import('../types.js').CommandDependencies} dependencies
  */
 export async function handlePlayerDimensionChangeAfterEvent(eventData, dependencies) {
     const { player, fromDimension, toDimension, fromLocation } = eventData;

--- a/AntiCheatsBP/scripts/core/playerDataManager.js
+++ b/AntiCheatsBP/scripts/core/playerDataManager.js
@@ -24,7 +24,6 @@ const persistedPlayerDataKeys = [
     'lastCombatInteractionTime', 'lastViolationDetailsMap', 'automodState',
     'joinTime',
     'lastKnownNameTag', 'lastNameTagChangeTick', 'deathMessageToShowOnSpawn',
-    // Per-check interval trackers are also persisted if they are top-level keys in pData.
     'lastCheckNameSpoofTick', 'lastCheckAntiGmcTick', 'lastCheckNetherRoofTick',
     'lastCheckAutoToolTick', 'lastCheckFlatRotationBuildingTick', 'lastRenderDistanceCheckTick',
 ];
@@ -78,8 +77,7 @@ export async function savePlayerDataToDynamicProperties(player, pDataToSave, dep
         return false;
     }
 
-    // Minecraft dynamic property string length limit is 32767 bytes.
-    if (jsonString.length > 32760) { // Buffer for safety
+    if (jsonString.length > 32760) { // Buffer for safety, limit is 32767
         playerUtils.debugLog(`PDM:save: pData too large for ${player.nameTag} (${jsonString.length}b). Cannot save to dynamic properties.`, player.nameTag, dependencies);
         console.warn(`[PlayerDataManager] pData for ${player.nameTag} exceeds dynamic property size limit.`);
         return false;
@@ -212,7 +210,6 @@ export function initializeDefaultPlayerData(player, currentTick, dependencies) {
         recentMessages: [],
         flags: {
             totalFlags: 0,
-            // Movement
             movementFlyHover: { count: 0, lastDetectionTime: 0 },
             movementSpeedGround: { count: 0, lastDetectionTime: 0 },
             movementNoFall: { count: 0, lastDetectionTime: 0 },
@@ -221,7 +218,6 @@ export function initializeDefaultPlayerData(player, currentTick, dependencies) {
             movementNetherRoof: { count: 0, lastDetectionTime: 0 },
             movementHighYVelocity: { count: 0, lastDetectionTime: 0 },
             movementSustainedFly: { count: 0, lastDetectionTime: 0 },
-            // Combat
             combatReachAttack: { count: 0, lastDetectionTime: 0 },
             combatCpsHigh: { count: 0, lastDetectionTime: 0 },
             combatViewSnapPitch: { count: 0, lastDetectionTime: 0 },
@@ -233,7 +229,6 @@ export function initializeDefaultPlayerData(player, currentTick, dependencies) {
             combatAttackWhileBowCharging: { count: 0, lastDetectionTime: 0 },
             combatAttackWhileShielding: { count: 0, lastDetectionTime: 0 },
             combatLog: { count: 0, lastDetectionTime: 0 },
-            // World Interaction
             worldNuker: { count: 0, lastDetectionTime: 0 },
             worldIllegalItemUse: { count: 0, lastDetectionTime: 0 },
             worldIllegalItemPlace: { count: 0, lastDetectionTime: 0 },
@@ -245,7 +240,6 @@ export function initializeDefaultPlayerData(player, currentTick, dependencies) {
             worldAutoTool: { count: 0, lastDetectionTime: 0 },
             worldInstaBreakUnbreakable: { count: 0, lastDetectionTime: 0 },
             worldInstaBreakSpeed: { count: 0, lastDetectionTime: 0 },
-            // Player Actions/State
             actionFastUse: { count: 0, lastDetectionTime: 0 },
             playerNameSpoof: { count: 0, lastDetectionTime: 0 },
             playerAntiGmc: { count: 0, lastDetectionTime: 0 },
@@ -255,7 +249,6 @@ export function initializeDefaultPlayerData(player, currentTick, dependencies) {
             playerSelfHurt: { count: 0, lastDetectionTime: 0 },
             playerClientAnomaly: { count: 0, lastDetectionTime: 0 },
             playerChatStateViolation: { count: 0, lastDetectionTime: 0 },
-            // Chat specific
             chatSpamFast: { count: 0, lastDetectionTime: 0 },
             chatSpamMaxWords: { count: 0, lastDetectionTime: 0 },
             chatLanguageViolation: { count: 0, lastDetectionTime: 0 },
@@ -270,7 +263,6 @@ export function initializeDefaultPlayerData(player, currentTick, dependencies) {
             chatImpersonationAttempt: { count: 0, lastDetectionTime: 0 },
             chatNewline: { count: 0, lastDetectionTime: 0 },
             chatMaxlength: { count: 0, lastDetectionTime: 0 },
-            // AntiGrief
             antiGriefTnt: { count: 0, lastDetectionTime: 0 },
             antiGriefWither: { count: 0, lastDetectionTime: 0 },
             antiGriefFire: { count: 0, lastDetectionTime: 0 },

--- a/AntiCheatsBP/scripts/main.js
+++ b/AntiCheatsBP/scripts/main.js
@@ -8,7 +8,6 @@
 import * as mc from '@minecraft/server';
 import * as mcui from '@minecraft/server-ui';
 
-// Local Modules
 import * as actionManager from './core/actionManager.js';
 import { automodConfig } from './core/automodConfig.js';
 import * as chatProcessor from './core/chatProcessor.js';
@@ -75,7 +74,6 @@ function getStandardDependencies() {
     };
 }
 
-// Event Subscriptions
 mc.world.beforeEvents.chatSend.subscribe(async (eventData) => {
     const dependencies = getStandardDependencies();
     if (eventData.message.startsWith(dependencies.config.prefix)) {
@@ -101,30 +99,15 @@ mc.world.afterEvents.playerSpawn.subscribe((eventData) => {
     eventHandlers.handlePlayerSpawn(eventData, getStandardDependencies());
 });
 
-/**
- * Handles player leave events:
- * - Performs cleanup of player data.
- * - Manages combat log detection.
- * - Saves player data if dirty.
- */
 mc.world.beforeEvents.playerLeave.subscribe((eventData) => {
     eventHandlers.handlePlayerLeave(eventData, getStandardDependencies());
 });
 
-/**
- * Handles entity hurt events (after):
- * - Processes data for combat checks (Reach, CPS, ViewSnap, SelfHurt, MultiTarget, StateConflict).
- * - Updates player combat state.
- */
 mc.world.afterEvents.entityHurt.subscribe((eventData) => {
     const dependencies = getStandardDependencies();
     eventHandlers.handleEntityHurt(eventData, dependencies);
 });
 
-/**
- * Handles entity hurt events (before):
- * - Specifically checks for TPA warmup cancellation if a player takes damage.
- */
 mc.world.beforeEvents.entityHurt.subscribe(eventData => {
     const dependencies = getStandardDependencies();
     if (!dependencies.config.enableTpaSystem || !dependencies.config.tpaTeleportWarmupSeconds || dependencies.config.tpaTeleportWarmupSeconds <= 0) {
@@ -150,69 +133,30 @@ mc.world.beforeEvents.entityHurt.subscribe(eventData => {
     }
 });
 
-/**
- * Handles player block break events (before):
- * - Checks for InstaBreak (unbreakable blocks).
- * - Gathers data for AutoTool check.
- */
 mc.world.beforeEvents.playerBreakBlock.subscribe(async (eventData) => {
     await eventHandlers.handlePlayerBreakBlockBeforeEvent(eventData, getStandardDependencies());
 });
-/**
- * Handles player block break events (after):
- * - Checks for Nuker.
- * - Checks for InstaBreak (speed).
- * - Provides data for X-Ray notifications.
- * - Updates player data related to block breaking.
- */
+
 mc.world.afterEvents.playerBreakBlock.subscribe(async (eventData) => {
     await eventHandlers.handlePlayerBreakBlockAfterEvent(eventData, getStandardDependencies());
 });
 
-/**
- * Handles item use events (e.g., eating, drinking, using ender pearls):
- * - Checks for FastUse violations.
- * - Manages player state related to item usage (e.g., `isUsingConsumable`).
- * - Checks for illegal item use.
- * - Handles chat interaction checks (e.g., `enableChatDuringItemUseCheck`).
- */
 mc.world.beforeEvents.itemUse.subscribe(async (eventData) => {
     await eventHandlers.handleItemUse(eventData, getStandardDependencies());
 });
-/**
- * Handles item use on a block events (e.g., placing a boat, using flint & steel):
- * - Checks for illegal item use on blocks.
- * - Handles anti-grief for specific items like TNT, Lava, Water (via entity spawn for some).
- * - Manages player state related to item usage.
- */
+
 mc.world.beforeEvents.itemUseOn.subscribe(async (eventData) => {
     await eventHandlers.handleItemUseOn(eventData, getStandardDependencies());
 });
 
-/**
- * Handles player block placement events (before):
- * - Checks for illegal block placement (e.g., banned items).
- * - Anti-grief checks for blocks like TNT.
- * - AirPlace check.
- */
 mc.world.beforeEvents.playerPlaceBlock.subscribe(async (eventData) => {
     await eventHandlers.handlePlayerPlaceBlockBefore(eventData, getStandardDependencies());
 });
-/**
- * Handles player block placement events (after):
- * - Checks for Scaffold/Tower, DownwardScaffold, FastPlace.
- * - Anti-grief checks (block spam rate/density).
- * - Updates player data related to block placement.
- */
+
 mc.world.afterEvents.playerPlaceBlock.subscribe(async (eventData) => {
     await eventHandlers.handlePlayerPlaceBlockAfterEvent(eventData, getStandardDependencies());
 });
 
-/**
- * Handles changes to a player's inventory items:
- * - Potential hook for InventoryModification checks (e.g., illegal items, enchantments).
- *   Currently, this is a basic stub.
- */
 mc.world.afterEvents.playerInventoryItemChange.subscribe(async (eventData) => {
     await eventHandlers.handleInventoryItemChange(
         eventData.player,
@@ -223,20 +167,10 @@ mc.world.afterEvents.playerInventoryItemChange.subscribe(async (eventData) => {
     );
 });
 
-/**
- * Handles player dimension change events:
- * - Updates player data related to their current dimension.
- * - Potentially re-evaluates world border status.
- */
 mc.world.afterEvents.playerDimensionChange.subscribe((eventData) => {
     eventHandlers.handlePlayerDimensionChangeAfterEvent(eventData, getStandardDependencies());
 });
 
-/**
- * Handles entity death events:
- * - If a player dies, triggers player death specific logic (e.g., death coordinates message).
- * - If death effects are enabled, triggers cosmetic effects.
- */
 mc.world.afterEvents.entityDie.subscribe((eventData) => {
     const dependencies = getStandardDependencies();
     if (eventData.deadEntity.typeId === mc.MinecraftEntityTypes.player.id) {
@@ -247,29 +181,17 @@ mc.world.afterEvents.entityDie.subscribe((eventData) => {
     }
 });
 
-/**
- * Handles entity spawn events (after):
- * - Anti-grief checks for entity spam (e.g., boats, armor stands).
- * - Anti-grief checks for Wither spawning.
- */
 mc.world.afterEvents.entitySpawn.subscribe(async (eventData) => {
     await eventHandlers.handleEntitySpawnEvent_AntiGrief(eventData, getStandardDependencies());
 });
 
-/**
- * Handles piston activation events (after):
- * - Checks for PistonLag machines by monitoring rapid activations.
- */
 mc.world.afterEvents.pistonActivate.subscribe(async (eventData) => {
     await eventHandlers.handlePistonActivate_AntiGrief(eventData, getStandardDependencies());
 });
 
-// System Intervals
 mc.system.runInterval(async () => {
     currentTick++;
     const tickDependencies = getStandardDependencies();
-
-    // ReportManager cache should be initialized once at startup.
 
     if (tickDependencies.config.enableWorldBorderSystem) {
         try {
@@ -294,7 +216,6 @@ mc.system.runInterval(async () => {
         playerDataManager.updateTransientPlayerData(player, pData, tickDependencies);
         playerDataManager.clearExpiredItemUseStates(pData, tickDependencies);
 
-        // Movement Checks
         if (tickDependencies.config.enableFlyCheck && checks.checkFly) await checks.checkFly(player, pData, tickDependencies);
         if (tickDependencies.config.enableSpeedCheck && checks.checkSpeed) await checks.checkSpeed(player, pData, tickDependencies);
         if (tickDependencies.config.enableNofallCheck && checks.checkNoFall) await checks.checkNoFall(player, pData, tickDependencies);
@@ -304,50 +225,38 @@ mc.system.runInterval(async () => {
              await checks.checkNetherRoof(player, pData, tickDependencies); pData.lastCheckNetherRoofTick = currentTick;
         }
 
-        // Combat Checks
         if (tickDependencies.config.enableCpsCheck && checks.checkCps) await checks.checkCps(player, pData, tickDependencies, null);
         if (tickDependencies.config.enableViewSnapCheck && checks.checkViewSnap) await checks.checkViewSnap(player, pData, tickDependencies, null);
-        if (tickDependencies.config.enableReachCheck && checks.checkReach) { /* checkReach typically runs on entityHurt */ }
+        // Reach check typically runs on entityHurt
         if (tickDependencies.config.enableMultiTargetCheck && checks.checkMultiTarget) await checks.checkMultiTarget(player, pData, tickDependencies, null);
         if (tickDependencies.config.enableStateConflictCheck && checks.checkStateConflict) await checks.checkStateConflict(player, pData, tickDependencies, null);
 
-        // World Interaction / Building Checks
         if (tickDependencies.config.enableNukerCheck && checks.checkNuker) await checks.checkNuker(player, pData, tickDependencies);
         if (tickDependencies.config.enableAutoToolCheck && checks.checkAutoTool && (currentTick - (pData.lastCheckAutoToolTick || 0) >= tickDependencies.config.autoToolCheckIntervalTicks)) {
             await checks.checkAutoTool(player, pData, tickDependencies); pData.lastCheckAutoToolTick = currentTick;
         }
-        if (tickDependencies.config.enableInstaBreakSpeedCheck && checks.checkInstaBreak) { /* InstaBreak typically runs on blockBreak */ }
-        // Removed tower check from tick, it's in PlayerPlaceBlockAfterEvent
+        // InstaBreak speed check typically runs on blockBreak
         if (tickDependencies.config.enableFlatRotationCheck && checks.checkFlatRotationBuilding && (currentTick - (pData.lastCheckFlatRotationBuildingTick || 0) >= tickDependencies.config.flatRotationCheckIntervalTicks)) {
             await checks.checkFlatRotationBuilding(player, pData, tickDependencies); pData.lastCheckFlatRotationBuildingTick = currentTick;
         }
-        // Downward scaffold check removed from tick, it's in PlayerPlaceBlockAfterEvent
-        if (tickDependencies.config.enableAirPlaceCheck && checks.checkAirPlace) { /* AirPlace typically runs on blockPlace */ }
-        // Removed fast place from tick, it's in PlayerPlaceBlockAfterEvent
+        // DownwardScaffold, AirPlace, FastPlace checks run on blockPlace events
 
-
-        // Player State / Info / Behavior Checks
         if (tickDependencies.config.enableNameSpoofCheck && checks.checkNameSpoof && (currentTick - (pData.lastCheckNameSpoofTick || 0) >= tickDependencies.config.nameSpoofCheckIntervalTicks)) {
             await checks.checkNameSpoof(player, pData, tickDependencies); pData.lastCheckNameSpoofTick = currentTick;
         }
         if (tickDependencies.config.enableAntiGmcCheck && checks.checkAntiGmc && (currentTick - (pData.lastCheckAntiGmcTick || 0) >= tickDependencies.config.antiGmcCheckIntervalTicks)) {
             await checks.checkAntiGmc(player, pData, tickDependencies); pData.lastCheckAntiGmcTick = currentTick;
         }
-        if (tickDependencies.config.enableSelfHurtCheck && checks.checkSelfHurt) { /* SelfHurt typically runs on entityHurt */ }
-        // Removed illegal item check from tick, it's event-based
-        // Removed inventory mod check from tick, it's event-based
+        // SelfHurt check typically runs on entityHurt
+        // Illegal item and inventory mod checks are event-based
 
-
-        // Client Behavior Checks
         if (tickDependencies.config.enableInvalidRenderDistanceCheck && checks.checkInvalidRenderDistance && (currentTick - (pData.lastRenderDistanceCheckTick || 0) >= tickDependencies.config.invalidRenderDistanceCheckIntervalTicks)) {
             await checks.checkInvalidRenderDistance(player, pData, tickDependencies);
             pData.lastRenderDistanceCheckTick = currentTick;
         }
 
-        // Item Use Checks
-        if (tickDependencies.config.enableFastUseCheck && checks.checkFastUse) { /* FastUse typically runs on itemUse event */ }
+        // FastUse check typically runs on itemUse event
 
-        // Fall distance accumulation
         if (!player.isOnGround) {
             if ((pData.velocity?.y ?? 0) < -0.078 && pData.previousPosition && pData.lastPosition) {
                 const deltaY = pData.previousPosition.y - pData.lastPosition.y;
@@ -362,9 +271,7 @@ mc.system.runInterval(async () => {
             pData.isTakingFallDamage = false; // Reset this flag after checking
             pData.consecutiveOffGroundTicks = 0;
         }
-        // previousPosition is updated in updateTransientPlayerData, so it's already set for next tick's deltaY calc.
 
-        // World Border Enforcement
         if (tickDependencies.config.enableWorldBorderSystem) {
             try {
                 worldBorderManager.enforceWorldBorderForPlayer(player, pData, tickDependencies);
@@ -388,7 +295,6 @@ mc.system.runInterval(async () => {
                         playerUtils.debugLog(`Periodic save executed for watched player ${player.nameTag}.`, player.nameTag, tickDependencies);
                     }
                 } catch (error) {
-                    // const err = error; // JavaScript doesn't have 'as Error' type casting
                     console.error(`Error during periodic save for ${player.nameTag}: ${error.message}`);
                     logManager.addLog({ actionType: 'error', context: 'PeriodicSaveFail', details: `Player: ${player.nameTag}, Error: ${error.message}` }, tickDependencies);
                 }
@@ -397,25 +303,12 @@ mc.system.runInterval(async () => {
         logManager.persistLogCacheToDisk(tickDependencies);
         reportManager.persistReportsToDisk(tickDependencies);
         if (tickDependencies.config.enableWorldBorderSystem) {
-            // Settings are saved when modified by commands. A global periodic save isn't strictly necessary
-            // unless there's a mechanism for settings to become "dirty" without explicit saves.
-            // For now, specific save calls are in the command logic.
-            // If a global save is desired, it would iterate dimensions and saveBorderSettings if a setting object is dirty.
-            // Example:
-            // const knownDims = tickDependencies.config.worldBorderKnownDimensions || ['minecraft:overworld', 'minecraft:the_nether', 'minecraft:the_end'];
-            // for (const dimId of knownDims) {
-            //    const settings = worldBorderManager.getBorderSettings(dimId, tickDependencies);
-            //    if (settings && settings.isDirtyForSave) { // Assuming an isDirtyForSave flag could be added
-            //        worldBorderManager.saveBorderSettings(dimId, settings, tickDependencies);
-            //        settings.isDirtyForSave = false;
-            //    }
-            // }
+            // Settings are saved when modified by commands.
             playerUtils.debugLog("[MainTick] World border settings are saved on modification. No global periodic save implemented currently.", "System", tickDependencies);
         }
     }
 }, 1);
 
-// TPA Processing
 mc.system.runInterval(() => {
     const tpaIntervalDependencies = getStandardDependencies();
     if (tpaIntervalDependencies.config.enableTpaSystem) {
@@ -429,33 +322,27 @@ mc.system.runInterval(() => {
     }
 }, 20); // Approx. every second
 
-// Initial System Setup
 function initializeSystem() {
     const startupDependencies = getStandardDependencies();
     playerUtils.debugLog('Anti-Cheat Script Loaded. Initializing modules...', 'System', startupDependencies);
 
     commandManager.initializeCommands(startupDependencies);
     logManager.initializeLogCache(startupDependencies);
-    reportManager.initializeReportCache(startupDependencies); // Moved here
+    reportManager.initializeReportCache(startupDependencies);
     rankManager.initializeRanks(startupDependencies);
     if (startupDependencies.config.enableWorldBorderSystem) {
         const knownDims = startupDependencies.config.worldBorderKnownDimensions || ['minecraft:overworld', 'minecraft:the_nether', 'minecraft:the_end'];
         for (const dimId of knownDims) {
-            // getBorderSettings effectively loads it into cache if accessed,
-            // actual "loading" into a manager-level cache isn't explicitly done here,
-            // but settings are read from properties when needed.
-            // We can call it to ensure it's read once if there's any internal caching in worldBorderManager.
+            // Ensure settings are loaded/initialized if worldBorderManager uses internal caching.
              worldBorderManager.getBorderSettings(dimId, startupDependencies);
         }
         playerUtils.debugLog("[InitializeSystem] World border settings will be loaded on demand for configured dimensions.", "System", startupDependencies);
     }
 
-
     playerUtils.debugLog('Anti-Cheat Core System Initialized. Event handlers and tick loop are active.', 'System', startupDependencies);
     mc.world.sendMessage('§a[AntiCheat] §2System Core Initialized. Version: ' + configModule.acVersion);
 }
 
-// Initialize after a short delay to ensure Minecraft modules are ready.
 mc.system.runTimeout(() => {
     initializeSystem();
 }, 1);

--- a/Dev/tasks/ongoing.md
+++ b/Dev/tasks/ongoing.md
@@ -2,6 +2,8 @@
 
 This document summarizes the current work-in-progress for the AntiCheat addon.
 
-*No tasks are currently ongoing.*
-
-(This file was cleared after the completion of the Comprehensive Codebase Review by Jules.)
+*   **Task:** Comprehensive Codebase Review and Refinement.
+    *   **Description:** Review the entire codebase to identify and address unused code, unnecessary comments, excessive empty lines, and potentially missing elements (e.g., documentation, error handling improvements).
+    *   **Status:** In progress.
+    *   **Current Focus:** Step 1 - Review JavaScript files for unnecessary comments and empty lines.
+    *   **Assignee:** Jules (AI Assistant)


### PR DESCRIPTION
This commit addresses the first part of a larger code review and cleanup task.

Work done so far:
- Updated `Dev/tasks/ongoing.md` to reflect the active task: Comprehensive Codebase Review and Refinement.
- `AntiCheatsBP/scripts/main.js`:
    - Removed commented-out code blocks.
    - Removed redundant/obvious comments (e.g., "Local Modules", "Event Subscriptions").
    - Adjusted empty lines for better readability and consistency.
- `AntiCheatsBP/scripts/core/eventHandlers.js`:
    - Removed several blocks of commented-out old code and placeholder comments.
    - Simplified JSDoc comments by removing overly verbose or redundant descriptions (e.g., "The event data.").
    - Adjusted empty lines for consistency.
- `AntiCheatsBP/scripts/core/playerDataManager.js`:
    - Removed a commented-out line regarding dynamic property size limits (information was already in logs/buffered code).
    - Removed a comment noting that per-check interval trackers are persisted, as this is evident from the `persistedPlayerDataKeys` array.
    - Removed internal sectioning comments (e.g., `// Movement`, `// Combat`) within the `initializeDefaultPlayerData` function, as the structure of the `flags` object itself provides this organization.

The overall goal is to improve code readability and maintainability by removing clutter. This is the first step in a multi-step plan to review and refine the entire codebase.