### PR TITLE
Refactor: Remove extensive debugging console logs

### DIFF
--- a/AntiCheatsBP/scripts/config.js
+++ b/AntiCheatsBP/scripts/config.js
@@ -1108,17 +1108,11 @@ export function updateConfigValue(key, newValue) {
     }
 
     if (JSON.stringify(oldValue) === JSON.stringify(coercedNewValue)) {
-        if (enableDebugLogging) {
-            console.log(`[ConfigManager] No change for ${key}, value is already ${JSON.stringify(coercedNewValue)}`);
-        }
+        // Debug log removed: console.log(`[ConfigManager] No change for ${key}, value is already ${JSON.stringify(coercedNewValue)}`);
         return false;
     }
 
     editableConfigValues[key] = coercedNewValue;
-    if (enableDebugLogging) {
-        const oldValStr = Array.isArray(oldValue) || typeof oldValue === 'object' ? JSON.stringify(oldValue) : oldValue;
-        const newValStr = Array.isArray(coercedNewValue) || typeof coercedNewValue === 'object' ? JSON.stringify(coercedNewValue) : coercedNewValue;
-        console.log(`[ConfigManager] Updated ${key} from "${oldValStr}" to "${newValStr}"`);
-    }
+    // Debug log removed: console.log(`[ConfigManager] Updated ${key} from "${oldValStr}" to "${newValStr}"`);
     return true;
 }

--- a/AntiCheatsBP/scripts/main.js
+++ b/AntiCheatsBP/scripts/main.js
@@ -463,15 +463,7 @@ function performInitializations() {
         currentTick++;
         const tickDependencies = getStandardDependencies();
 
-        // --- BEGIN TICK LOOP DIAGNOSTICS ---
-        if (tickDependencies.config.enableDebugLogging && (currentTick === 1 || currentTick % 200 === 0)) {
-            const logger = (playerUtils && typeof playerUtils.debugLog === 'function') ? (msg) => playerUtils.debugLog(msg, 'System', tickDependencies) : console.log;
-            logger(`[TickLoopDiag] Tick: ${currentTick}`);
-            logger(`[TickLoopDiag] typeof mc.world: ${typeof mc.world}`);
-            if (mc.world) {
-                logger(`[TickLoopDiag] typeof mc.world.getAllPlayers: ${typeof mc.world.getAllPlayers}`);
-            }
-        }
+        // --- BEGIN TICK LOOP DIAGNOSTICS --- (Removed)
         // --- END TICK LOOP DIAGNOSTICS ---
 
         if (tickDependencies.config.enableWorldBorderSystem) {
@@ -488,42 +480,33 @@ function performInitializations() {
         try {
             if (mc.world && typeof mc.world.getAllPlayers === 'function') {
                 allPlayers = mc.world.getAllPlayers();
-                if (tickDependencies.config.enableDebugLogging && (currentTick === 1 || currentTick % 200 === 0)) {
-                    const logger = (playerUtils && typeof playerUtils.debugLog === 'function') ? (msg) => playerUtils.debugLog(msg, 'System', tickDependencies) : console.log;
-                    logger(`[TickLoopDiag] mc.world.getAllPlayers() returned array of length: ${allPlayers.length}`);
-                }
+                // Removed: TickLoopDiag for getAllPlayers length
             } else {
-                if (tickDependencies.config.enableDebugLogging && (currentTick === 1 || currentTick % 200 === 0)) {
-                    const logger = (playerUtils && typeof playerUtils.debugLog === 'function') ? (msg) => playerUtils.debugLog(msg, 'System', tickDependencies) : console.error;
-                    logger('[TickLoopDiag] mc.world or mc.world.getAllPlayers is not available!');
-                }
+                // Removed: TickLoopDiag for mc.world or getAllPlayers not available
+                 if (currentTick === 1 || currentTick % 600 === 0) { // Log less frequently if system isn't fully ready
+                    console.error('[AntiCheatCoreTick] mc.world or mc.world.getAllPlayers is not available!');
+                 }
             }
         } catch (e) {
             // This error is critical enough to always log if it happens.
-            console.error(`[TickLoopDiag] Error calling mc.world.getAllPlayers(): ${e}`);
+            console.error(`[AntiCheatCoreTick] Error calling mc.world.getAllPlayers(): ${e}`);
         }
 
         playerDataManager.cleanupActivePlayerData(allPlayers, tickDependencies);
 
         for (const player of allPlayers) {
-            // --- BEGIN PLAYER LOOP DIAGNOSTICS ---
-            if (tickDependencies.config.enableDebugLogging && (currentTick === 1 || currentTick % 200 === 0)) { // Log less frequently
-                const logger = (playerUtils && typeof playerUtils.debugLog === 'function') ? (msg) => playerUtils.debugLog(msg, player?.nameTag, tickDependencies) : (msg) => console.log(`[Player: ${player?.nameTag}] ${msg}`);
-                logger(`[TickLoopDiag] Processing player (type: ${typeof player})`);
-            }
+            // --- BEGIN PLAYER LOOP DIAGNOSTICS --- (Removed)
             // --- END PLAYER LOOP DIAGNOSTICS ---
 
             let pData;
             try {
                 pData = await playerDataManager.ensurePlayerDataInitialized(player, currentTick, tickDependencies);
-                if (tickDependencies.config.enableDebugLogging && (currentTick === 1 || currentTick % 200 === 0)) { // Log less frequently
-                    const logger = (playerUtils && typeof playerUtils.debugLog === 'function') ? (msg) => playerUtils.debugLog(msg, player?.nameTag, tickDependencies) : (msg) => console.log(`[Player: ${player?.nameTag}] ${msg}`);
-                    logger(`[TickLoopDiag] pData: typeof=${typeof pData}, totalFlags=${pData?.flags?.totalFlags ?? 'N/A'}`);
-                }
+                // Removed: TickLoopDiag for pData details
             } catch (e) {
-                console.error(`[TickLoopDiag] Error in ensurePlayerDataInitialized for ${player?.nameTag}: ${e}`);
+                // This console.error is important if ensurePlayerDataInitialized fails.
+                console.error(`[AntiCheatCoreTick] Error in ensurePlayerDataInitialized for ${player?.nameTag}: ${e}`);
                 if (playerUtils && typeof playerUtils.debugLog === 'function') {
-                    playerUtils.debugLog(`[TickLoopDiag] Error in ensurePlayerDataInitialized for ${player?.nameTag}: ${e}`, player?.nameTag, tickDependencies);
+                    playerUtils.debugLog(`[AntiCheatCoreTick] Error in ensurePlayerDataInitialized for ${player?.nameTag}: ${e}`, player?.nameTag, tickDependencies);
                 }
                 continue; // Skip this player if pData init fails
             }


### PR DESCRIPTION
Removed various console.log and console.error statements that were identified as being for debugging purposes, particularly in config.js, rankManager.js, and the main tick loop in main.js.

Kept console outputs that are for legitimate warnings, error reporting, or essential system feedback (e.g., admin command logs, initialization status).