### PR TITLE
Feat: Implement TPA cancellation on player movement during warmup

### DIFF
--- a/AntiCheatsBP/scripts/config.js
+++ b/AntiCheatsBP/scripts/config.js
@@ -51,6 +51,10 @@ export const tpaRequestTimeoutSeconds = 60;
 export const tpaRequestCooldownSeconds = 10;
 /** @type {number} Seconds of warmup before a player is teleported after a TPA request is accepted. Movement or damage cancels it. */
 export const tpaTeleportWarmupSeconds = 10;
+/** @type {boolean} If true, TPA is cancelled if the teleporting player moves during the warmup period. */
+export const tpaCancelOnMoveDuringWarmup = true;
+/** @type {number} Maximum distance (in blocks) a player can move during TPA warmup before it's cancelled. */
+export const tpaMovementTolerance = 0.5;
 
 // --- Server Info & Links ---
 /** @type {string} Link to the server's Discord. Displayed in help or server info commands. */
@@ -770,6 +774,8 @@ export let editableConfigValues = {
     tpaRequestTimeoutSeconds,
     tpaRequestCooldownSeconds,
     tpaTeleportWarmupSeconds,
+    tpaCancelOnMoveDuringWarmup,
+    tpaMovementTolerance,
     // Server Info & Links
     discordLink,
     websiteLink,

--- a/AntiCheatsBP/scripts/core/textDatabase.js
+++ b/AntiCheatsBP/scripts/core/textDatabase.js
@@ -270,6 +270,8 @@ export const stringDB = {
     'tpa.manager.decline.otherCancelledTarget': '§cThe TPA request from {requesterPlayerName} was cancelled.',
     'tpa.manager.expired.requesterNotified': '§cYour TPA request to {targetName} has expired.',
     'tpa.manager.expired.targetNotified': '§cThe TPA request from {requesterName} has expired.',
+    'tpa.manager.cancelled.movementDuringWarmup': '§cTPA cancelled: {playerName} moved during warm-up!',
+    'tpa.manager.error.teleportWarmupTargetInvalid': '§cTPA cancelled: {otherPlayerName} is no longer valid for teleport.',
 
     // Command specific: addrank
     'command.addrank.usage': '§cUsage: {prefix}addrank <playername> <rankId>',

--- a/AntiCheatsBP/scripts/main.js
+++ b/AntiCheatsBP/scripts/main.js
@@ -535,12 +535,17 @@ function performInitializations() {
             tpaManager.clearExpiredRequests(tpaIntervalDependencies);
             const requestsInWarmup = tpaManager.getRequestsInWarmup();
             for (const request of requestsInWarmup) {
-                if (Date.now() >= (request.warmupExpiryTimestamp || 0)) {
+                // Check for movement first if the feature is enabled
+                if (tpaIntervalDependencies.config.tpaCancelOnMoveDuringWarmup) { // This config will be added later
+                    tpaManager.checkPlayerMovementDuringWarmup(request, tpaIntervalDependencies);
+                }
+                // If the request is still valid (not cancelled by movement), check for expiry
+                if (request.status === 'pending_teleport_warmup' && Date.now() >= (request.warmupExpiryTimestamp || 0)) {
                     tpaManager.executeTeleport(request.requestId, tpaIntervalDependencies);
                 }
             }
         }
-    }, 20);
+    }, 20); // Runs every second (20 ticks)
 }
 
 

--- a/AntiCheatsBP/scripts/types.js
+++ b/AntiCheatsBP/scripts/types.js
@@ -218,6 +218,7 @@
  * @property {'pending_acceptance'|'pending_teleport_warmup'|'teleporting'|'cancelled_by_requester'|'cancelled_by_target'|'cancelled_by_system'|'cancelled_damage'|'completed'|'expired'} [status='pending_acceptance'] Current status of the TPA request.
  * @property {number} [warmupExpiryTimestamp] Unix timestamp (ms) when teleport warmup ends (if applicable).
  * @property {string} [cancellationReason] Reason if the request was cancelled.
+ * @property {Vector3} [teleportingPlayerInitialLocation] Initial location of the player who will be teleported, captured at warmup start.
  */
 
 /**


### PR DESCRIPTION
- Added functionality to cancel an active TPA teleport if the teleporting player moves beyond a configurable tolerance during the warmup period.
- Introduced config options `tpaCancelOnMoveDuringWarmup` (boolean) to enable/disable this feature and `tpaMovementTolerance` (number) to set the allowed movement distance.
- Modified `tpaManager.js` to store the initial location of the teleporting player upon TPA acceptance and to check their movement periodically during warmup.
- Updated `main.js` to call the movement check in its TPA processing loop.
- Added new text strings for cancellation messages to `textDatabase.js`.