### PR TITLE
Fix: Define missing constants in config.js

### DIFF
--- a/AntiCheatsBP/scripts/config.js
+++ b/AntiCheatsBP/scripts/config.js
@@ -727,6 +727,12 @@ export const invalidRenderDistanceCheckIntervalTicks = 400; // 20 seconds
 /** @type {string} The current version of the AntiCheat system. Updated by build process. */
 export const acVersion = 'v__VERSION_STRING__';
 
+// --- Command Specific Configs ---
+/** @type {number} Number of empty lines sent by !clearchat command to clear chat. */
+export const chatClearLinesCount = 150;
+/** @type {number} Number of reports displayed per page in the !viewreports command. */
+export const reportsViewPerPage = 5;
+
 // --- Command Aliases ---
 /** @type {Object.<string, string>} Defines aliases for commands. Key is alias, value is the actual command name. */
 export const commandAliases = {


### PR DESCRIPTION
Defines `chatClearLinesCount` and `reportsViewPerPage` as top-level constants in `AntiCheatsBP/scripts/config.js` before their use in `editableConfigValues`.

This prevents a potential issue where these values could be undefined during the initialization of `editableConfigValues` if accessed before being set by a command.