### PR TITLE
Fix: Address numerous ESLint JSDoc and style warnings

### DIFF
--- a/AntiCheatsBP/scripts/checks/movement/noFallCheck.js
+++ b/AntiCheatsBP/scripts/checks/movement/noFallCheck.js
@@ -24,7 +24,7 @@ const DEFAULT_MIN_FALL_DISTANCE_FOR_DAMAGE = 3.5;
  * @async
  * @param {import('@minecraft/server').Player} player - The player instance to check.
  * @param {PlayerAntiCheatData} pData - Player-specific anti-cheat data. Expected to contain `fallDistance`,
- *                                     `isTakingFallDamage`, `hasSlowFalling`, `lastOnSlimeBlockTick`, etc.
+ * `isTakingFallDamage`, `hasSlowFalling`, `lastOnSlimeBlockTick`, etc.
  * @param {Dependencies} dependencies - The standard dependencies object, including `currentTick`.
  * @returns {Promise<void>}
  */

--- a/AntiCheatsBP/scripts/checks/player/inventoryModCheck.js
+++ b/AntiCheatsBP/scripts/checks/player/inventoryModCheck.js
@@ -75,8 +75,8 @@ export async function checkSwitchAndUseInSameTick(player, pData, dependencies, e
  * @param {PlayerAntiCheatData} pData - Player-specific anti-cheat data.
  * @param {Dependencies} dependencies - Object containing necessary dependencies.
  * @param {EventSpecificData} eventSpecificData - Data specific to the event, expects `inventoryChangeDetails`
- *                                                (which should mirror structure of `PlayerInventoryItemChangeAfterEvent`'s eventData
- *                                                like `newItemStack`, `oldItemStack`, `inventorySlot`).
+ * (which should mirror structure of `PlayerInventoryItemChangeAfterEvent`'s eventData
+ * like `newItemStack`, `oldItemStack`, `inventorySlot`).
  * @returns {Promise<void>}
  */
 export async function checkInventoryMoveWhileActionLocked(player, pData, dependencies, eventSpecificData) {

--- a/AntiCheatsBP/scripts/checks/world/illegalItemCheck.js
+++ b/AntiCheatsBP/scripts/checks/world/illegalItemCheck.js
@@ -12,7 +12,7 @@
  * @param {mc.Player} player - The player performing the action.
  * @param {mc.ItemStack | undefined} itemStack - The ItemStack involved in the action. Can be undefined if player's hand is empty.
  * @param {(mc.ItemUseBeforeEvent | mc.ItemUseOnBeforeEvent | mc.PlayerPlaceBlockBeforeEvent) & {cancel: boolean, block?: mc.Block, source?: mc.Entity}} eventData - The event data object.
- *        Must have a `cancel` property. For 'place' actions, `eventData.block` is used. For 'use', `eventData.source` might be relevant.
+ * Must have a `cancel` property. For 'place' actions, `eventData.block` is used. For 'use', `eventData.source` might be relevant.
  * @param {'use' | 'place' | 'inventory_change'} actionType - The type of action being performed.
  * @param {import('../../types.js').PlayerAntiCheatData | undefined} pData - Player-specific anti-cheat data (primarily for `isWatched` status).
  * @param {import('../../types.js').Dependencies} dependencies - The standard dependencies object.

--- a/AntiCheatsBP/scripts/commands/report.js
+++ b/AntiCheatsBP/scripts/commands/report.js
@@ -19,10 +19,11 @@ export const definition = {
 };
 
 /**
+ * Executes the report command.
  *
- * @param player
- * @param args
- * @param dependencies
+ * @param {import('@minecraft/server').Player} player - The player executing the command.
+ * @param {string[]} args - The command arguments (target player name and reason).
+ * @param {import('../types.js').Dependencies} dependencies - The standard command dependencies.
  */
 export function execute(player, args, dependencies) {
     const { config, playerUtils, logManager, getString } = dependencies;

--- a/AntiCheatsBP/scripts/config.js
+++ b/AntiCheatsBP/scripts/config.js
@@ -279,10 +279,10 @@ const defaultConfigSettings = {
      * `volume`: (number, optional) Sound volume, typically 0.0 to 1.0. Defaults to 1.0.
      * `pitch`: (number, optional) Sound pitch. Defaults to 1.0.
      * `target`: (string, optional) Who hears the sound:
-     *           - "player": The player directly involved in or causing the event.
-     *           - "admin": All online administrators who have notifications enabled.
-     *           - "targetPlayer": A specific target player of an action (e.g., for TPA).
-     *           - "global": All online players (use with extreme caution).
+     * - "player": The player directly involved in or causing the event.
+     * - "admin": All online administrators who have notifications enabled.
+     * - "targetPlayer": A specific target player of an action (e.g., for TPA).
+     * - "global": All online players (use with extreme caution).
      * `description`: (string) A human-readable description of when this sound plays.
      */
     soundEvents: {
@@ -345,7 +345,7 @@ const defaultConfigSettings = {
     },
 
     // --- Command Specific Toggles & Values ---
-    /** @type {Object.<string, {enabled: boolean}>} Allows toggling individual commands on or off. */
+    /** @type {{[key: string]: {enabled: boolean}}} Allows toggling individual commands on or off. */
     commandSettings: {
         version: { enabled: true },
         myflags: { enabled: true },
@@ -741,7 +741,7 @@ Rule 6: Have fun and contribute to a positive community!`,
     deathEffectParticleName: 'minecraft:totem_particle',
     /** @type {string} The sound ID to play when a player dies (e.g., "mob.ghast.scream"). */
     deathEffectSoundId: 'mob.ghast.scream',
-    /** @type {object} Defines the default cosmetic effect shown when a player dies (legacy, can be expanded). */
+    /** @type {{soundId: string, particleCommand: string, soundOptions: {volume: number, pitch: number}}} Defines the default cosmetic effect shown when a player dies (legacy, can be expanded). */
     defaultDeathEffect: {
         soundId: 'ambient.weather.lightning.impact',
         particleCommand: 'particle minecraft:large_explosion ~ ~1 ~',
@@ -792,7 +792,8 @@ export const acVersion = 'v__VERSION_STRING__';
 // Complex objects like `automodConfig` or `checkActionProfiles` are imported and managed by their own modules
 // and are not part of this editableConfigValues structure directly.
 /**
- *
+ * @description Holds all configuration settings that can be modified at runtime.
+ * Initialized with values from `defaultConfigSettings`.
  */
 export const editableConfigValues = { ...defaultConfigSettings };
 

--- a/AntiCheatsBP/scripts/core/actionProfiles.js
+++ b/AntiCheatsBP/scripts/core/actionProfiles.js
@@ -7,7 +7,7 @@
  * @typedef {import('../types.js').ActionProfileNotify} ActionProfileNotify
  * @typedef {import('../types.js').ActionProfileLog} ActionProfileLog
  * @typedef {import('../types.js').ActionProfileEntry} ActionProfileEntry
- * @type {Object.<string, ActionProfileEntry>}
+ * @type {{[key: string]: import('../types.js').ActionProfileEntry}}
  */
 export const checkActionProfiles = {
     // Movement Checks

--- a/AntiCheatsBP/scripts/core/commandManager.js
+++ b/AntiCheatsBP/scripts/core/commandManager.js
@@ -112,11 +112,15 @@ export function unregisterCommandInternal(commandName, dependencies) {
 // For initial load, aliasToCommandMap will be empty or populated based on command files.
 (() => {
     const initialLoadDeps = {
-        playerUtils: { /**
-                        *
-                        * @param msg
-                        */
-            debugLog: (msg) => console.log(`[CommandManagerInitialLoad] ${msg}`) },
+        playerUtils: {
+            /**
+             * Minimal debug logger for initial command load.
+             *
+             * @param {string} msg - The message to log.
+             * @returns {void}
+             */
+            debugLog: (msg) => console.log(`[CommandManagerInitialLoad] ${msg}`),
+        },
         // config: {} // config.commandAliases is no longer used for alias resolution
         // aliasToCommandMap will be initialized within initializeCommands
     };

--- a/AntiCheatsBP/scripts/core/configValidator.js
+++ b/AntiCheatsBP/scripts/core/configValidator.js
@@ -319,12 +319,15 @@ export function validateMainConfig(config, actionProfiles, knownCommands, comman
         { name: 'enableSwearCheck', type: 'boolean' },
         { name: 'swearWordList', type: 'array', arrayElementType: 'string' },
         { name: 'swearCheckMuteDuration', type: 'durationString' },
-        { name: 'swearCheckActionProfileName', type: 'string', /**
-                                                                *
-                                                                * @param val
-                                                                * @param path
-                                                                * @param errs
-                                                                */
+        { name: 'swearCheckActionProfileName', type: 'string',
+            /**
+             * Validates that the action profile name exists.
+             *
+             * @param {string} val - The value of the action profile name.
+             * @param {string} path - The JSDoc path to the value being validated.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True if valid, false otherwise.
+             */
             validator: (val, path, errs) => {
                 if (!actionProfileNames.includes(val)) {
                     errs.push(`${path}: Action profile "${val}" not found in actionProfiles.js.`);
@@ -333,12 +336,15 @@ export function validateMainConfig(config, actionProfiles, knownCommands, comman
             } },
         { name: 'enableAntiAdvertisingCheck', type: 'boolean' },
         { name: 'antiAdvertisingPatterns', type: 'array', arrayElementType: 'string' },
-        { name: 'antiAdvertisingActionProfileName', type: 'string', /**
-                                                                     *
-                                                                     * @param val
-                                                                     * @param path
-                                                                     * @param errs
-                                                                     */
+        { name: 'antiAdvertisingActionProfileName', type: 'string',
+            /**
+             * Validates that the action profile name exists.
+             *
+             * @param {string} val - The value of the action profile name.
+             * @param {string} path - The JSDoc path to the value being validated.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True if valid, false otherwise.
+             */
             validator: (val, path, errs) => {
                 if (!actionProfileNames.includes(val)) {
                     errs.push(`${path}: Action profile "${val}" not found in actionProfiles.js.`);
@@ -346,12 +352,15 @@ export function validateMainConfig(config, actionProfiles, knownCommands, comman
                 return actionProfileNames.includes(val);
             } },
         { name: 'enableAdvancedLinkDetection', type: 'boolean' },
-        { name: 'advancedLinkRegexList', type: 'array', arrayElementType: 'string', /**
-                                                                                     *
-                                                                                     * @param val
-                                                                                     * @param path
-                                                                                     * @param errs
-                                                                                     */
+        { name: 'advancedLinkRegexList', type: 'array', arrayElementType: 'string',
+            /**
+             * Validates regex patterns in an array.
+             *
+             * @param {string[]} val - Array of regex strings.
+             * @param {string} path - The JSDoc path to the array.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True (as errors are pushed directly).
+             */
             validator: (val, path, errs) => {
                 val.forEach((regex, index) => {
                     try {
@@ -366,24 +375,30 @@ export function validateMainConfig(config, actionProfiles, knownCommands, comman
         { name: 'advertisingWhitelistPatterns', type: 'array', arrayElementType: 'string' }, // Could also be regex
         { name: 'enableCapsCheck', type: 'boolean' },
         { name: 'capsCheckMinLength', type: 'nonNegativeNumber' },
-        { name: 'capsCheckUpperCasePercentage', type: 'number', /**
-                                                                 *
-                                                                 * @param val
-                                                                 * @param path
-                                                                 * @param errs
-                                                                 */
+        { name: 'capsCheckUpperCasePercentage', type: 'number',
+            /**
+             * Validates a number is within a specific range (0-100).
+             *
+             * @param {number} val - The number to validate.
+             * @param {string} path - The JSDoc path to the value.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True if valid.
+             */
             validator: (val, path, errs) => {
                 if (val < 0 || val > 100) {
                     errs.push(`${path}: Must be between 0 and 100. Got ${val}.`);
                 }
                 return val >= 0 && val <= 100;
             } },
-        { name: 'capsCheckActionProfileName', type: 'string', /**
-                                                               *
-                                                               * @param val
-                                                               * @param path
-                                                               * @param errs
-                                                               */
+        { name: 'capsCheckActionProfileName', type: 'string',
+            /**
+             * Validates that the action profile name exists.
+             *
+             * @param {string} val - The value of the action profile name.
+             * @param {string} path - The JSDoc path to the value being validated.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True if valid, false otherwise.
+             */
             validator: (val, path, errs) => {
                 if (!actionProfileNames.includes(val)) {
                     errs.push(`${path}: Action profile "${val}" not found in actionProfiles.js.`);
@@ -391,108 +406,135 @@ export function validateMainConfig(config, actionProfiles, knownCommands, comman
                 return actionProfileNames.includes(val);
             } },
         // ... (add more chat check fields)
-        { name: 'charRepeatActionProfileName', type: 'string', /**
-                                                                *
-                                                                * @param val
-                                                                * @param path
-                                                                * @param errs
-                                                                */
+        { name: 'charRepeatActionProfileName', type: 'string',
+            /**
+             * Validates that the action profile name exists.
+             *
+             * @param {string} val - The value of the action profile name.
+             * @param {string} path - The JSDoc path to the value being validated.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True if valid, false otherwise.
+             */
             validator: (val, path, errs) => {
                 if (!actionProfileNames.includes(val)) {
                     errs.push(`${path}: Action profile "${val}" not found in actionProfiles.js.`);
                 }
                 return actionProfileNames.includes(val);
             } },
-        { name: 'symbolSpamActionProfileName', type: 'string', /**
-                                                                *
-                                                                * @param val
-                                                                * @param path
-                                                                * @param errs
-                                                                */
+        { name: 'symbolSpamActionProfileName', type: 'string',
+            /**
+             * Validates that the action profile name exists.
+             *
+             * @param {string} val - The value of the action profile name.
+             * @param {string} path - The JSDoc path to the value being validated.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True if valid, false otherwise.
+             */
             validator: (val, path, errs) => {
                 if (!actionProfileNames.includes(val)) {
                     errs.push(`${path}: Action profile "${val}" not found in actionProfiles.js.`);
                 }
                 return actionProfileNames.includes(val);
             } },
-        { name: 'fastMessageSpamActionProfileName', type: 'string', /**
-                                                                     *
-                                                                     * @param val
-                                                                     * @param path
-                                                                     * @param errs
-                                                                     */
+        { name: 'fastMessageSpamActionProfileName', type: 'string',
+            /**
+             * Validates that the action profile name exists.
+             *
+             * @param {string} val - The value of the action profile name.
+             * @param {string} path - The JSDoc path to the value being validated.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True if valid, false otherwise.
+             */
             validator: (val, path, errs) => {
                 if (!actionProfileNames.includes(val)) {
                     errs.push(`${path}: Action profile "${val}" not found in actionProfiles.js.`);
                 }
                 return actionProfileNames.includes(val);
             } },
-        { name: 'maxWordsSpamActionProfileName', type: 'string', /**
-                                                                  *
-                                                                  * @param val
-                                                                  * @param path
-                                                                  * @param errs
-                                                                  */
+        { name: 'maxWordsSpamActionProfileName', type: 'string',
+            /**
+             * Validates that the action profile name exists.
+             *
+             * @param {string} val - The value of the action profile name.
+             * @param {string} path - The JSDoc path to the value being validated.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True if valid, false otherwise.
+             */
             validator: (val, path, errs) => {
                 if (!actionProfileNames.includes(val)) {
                     errs.push(`${path}: Action profile "${val}" not found in actionProfiles.js.`);
                 }
                 return actionProfileNames.includes(val);
             } },
-        { name: 'chatContentRepeatActionProfileName', type: 'string', /**
-                                                                       *
-                                                                       * @param val
-                                                                       * @param path
-                                                                       * @param errs
-                                                                       */
+        { name: 'chatContentRepeatActionProfileName', type: 'string',
+            /**
+             * Validates that the action profile name exists.
+             *
+             * @param {string} val - The value of the action profile name.
+             * @param {string} path - The JSDoc path to the value being validated.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True if valid, false otherwise.
+             */
             validator: (val, path, errs) => {
                 if (!actionProfileNames.includes(val)) {
                     errs.push(`${path}: Action profile "${val}" not found in actionProfiles.js.`);
                 }
                 return actionProfileNames.includes(val);
             } },
-        { name: 'unicodeAbuseActionProfileName', type: 'string', /**
-                                                                  *
-                                                                  * @param val
-                                                                  * @param path
-                                                                  * @param errs
-                                                                  */
+        { name: 'unicodeAbuseActionProfileName', type: 'string',
+            /**
+             * Validates that the action profile name exists.
+             *
+             * @param {string} val - The value of the action profile name.
+             * @param {string} path - The JSDoc path to the value being validated.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True if valid, false otherwise.
+             */
             validator: (val, path, errs) => {
                 if (!actionProfileNames.includes(val)) {
                     errs.push(`${path}: Action profile "${val}" not found in actionProfiles.js.`);
                 }
                 return actionProfileNames.includes(val);
             } },
-        { name: 'gibberishActionProfileName', type: 'string', /**
-                                                               *
-                                                               * @param val
-                                                               * @param path
-                                                               * @param errs
-                                                               */
+        { name: 'gibberishActionProfileName', type: 'string',
+            /**
+             * Validates that the action profile name exists.
+             *
+             * @param {string} val - The value of the action profile name.
+             * @param {string} path - The JSDoc path to the value being validated.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True if valid, false otherwise.
+             */
             validator: (val, path, errs) => {
                 if (!actionProfileNames.includes(val)) {
                     errs.push(`${path}: Action profile "${val}" not found in actionProfiles.js.`);
                 }
                 return actionProfileNames.includes(val);
             } },
-        { name: 'mentionsActionProfileName', type: 'string', /**
-                                                              *
-                                                              * @param val
-                                                              * @param path
-                                                              * @param errs
-                                                              */
+        { name: 'mentionsActionProfileName', type: 'string',
+            /**
+             * Validates that the action profile name exists.
+             *
+             * @param {string} val - The value of the action profile name.
+             * @param {string} path - The JSDoc path to the value being validated.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True if valid, false otherwise.
+             */
             validator: (val, path, errs) => {
                 if (!actionProfileNames.includes(val)) {
                     errs.push(`${path}: Action profile "${val}" not found in actionProfiles.js.`);
                 }
                 return actionProfileNames.includes(val);
             } },
-        { name: 'impersonationActionProfileName', type: 'string', /**
-                                                                   *
-                                                                   * @param val
-                                                                   * @param path
-                                                                   * @param errs
-                                                                   */
+        { name: 'impersonationActionProfileName', type: 'string',
+            /**
+             * Validates that the action profile name exists.
+             *
+             * @param {string} val - The value of the action profile name.
+             * @param {string} path - The JSDoc path to the value being validated.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True if valid, false otherwise.
+             */
             validator: (val, path, errs) => {
                 if (!actionProfileNames.includes(val)) {
                     errs.push(`${path}: Action profile "${val}" not found in actionProfiles.js.`);
@@ -503,12 +545,15 @@ export function validateMainConfig(config, actionProfiles, knownCommands, comman
 
         // AntiGrief
         { name: 'enableTntAntiGrief', type: 'boolean' },
-        { name: 'tntPlacementAction', type: 'string', /**
-                                                       *
-                                                       * @param val
-                                                       * @param path
-                                                       * @param errs
-                                                       */
+        { name: 'tntPlacementAction', type: 'string',
+            /**
+             * Validates the action string against a list of allowed values.
+             *
+             * @param {string} val - The action string.
+             * @param {string} path - The JSDoc path to the value.
+             * @param {string[]} errs - Array to push error messages to.
+             * @returns {boolean} True if valid.
+             */
             validator: (val, path, errs) => {
                 const valid = ['remove', 'warn', 'flagOnly'];
                 if (!valid.includes(val)) {
@@ -519,12 +564,15 @@ export function validateMainConfig(config, actionProfiles, knownCommands, comman
         // ... (add more AntiGrief fields)
 
         // Sound Events
-        { name: 'soundEvents', type: 'object', /**
-                                                *
-                                                * @param soundEventsObj
-                                                * @param sePath
-                                                * @param seErrs
-                                                */
+        { name: 'soundEvents', type: 'object',
+            /**
+             * Validates the structure of the soundEvents object.
+             *
+             * @param {object} soundEventsObj - The soundEvents object.
+             * @param {string} sePath - The JSDoc path to this object.
+             * @param {string[]} seErrs - Array to push error messages to.
+             * @returns {boolean} True if all sound event definitions are valid.
+             */
             validator: (soundEventsObj, sePath, seErrs) => {
                 let overallSoundEventsValid = true;
                 for (const eventName in soundEventsObj) {
@@ -538,12 +586,15 @@ export function validateMainConfig(config, actionProfiles, knownCommands, comman
                         { name: 'soundId', type: 'string', optional: true }, // Can be empty for no sound
                         { name: 'volume', type: 'number', optional: true }, // Specific range check below
                         { name: 'pitch', type: 'number', optional: true },
-                        { name: 'target', type: 'string', optional: true, /**
-                                                                           *
-                                                                           * @param val
-                                                                           * @param p
-                                                                           * @param e
-                                                                           */
+                        { name: 'target', type: 'string', optional: true,
+                            /**
+                             * Validates the sound event target string.
+                             *
+                             * @param {string} val - The target string.
+                             * @param {string} p - The JSDoc path to the value.
+                             * @param {string[]} e - Array to push error messages to.
+                             * @returns {boolean} True if valid.
+                             */
                             validator: (val, p, e) => {
                                 const validTargets = ['player', 'admin', 'targetPlayer', 'global'];
                                 if (val && !validTargets.includes(val)) {
@@ -569,12 +620,15 @@ export function validateMainConfig(config, actionProfiles, knownCommands, comman
             } },
 
         // Command Settings
-        { name: 'commandSettings', type: 'object', /**
-                                                    *
-                                                    * @param cmdSettingsObj
-                                                    * @param csPath
-                                                    * @param csErrs
-                                                    */
+        { name: 'commandSettings', type: 'object',
+            /**
+             * Validates the commandSettings object.
+             *
+             * @param {object} cmdSettingsObj - The commandSettings object.
+             * @param {string} csPath - The JSDoc path to this object.
+             * @param {string[]} csErrs - Array to push error messages to.
+             * @returns {boolean} True if all command settings are valid.
+             */
             validator: (cmdSettingsObj, csPath, csErrs) => {
                 let overallIsValid = true;
                 for (const cmdName of Object.keys(cmdSettingsObj)) {
@@ -717,12 +771,15 @@ export function validateActionProfiles(actionProfiles) {
             ] },
             { name: 'cancelMessage', type: 'boolean', optional: true },
             { name: 'cancelEvent', type: 'boolean', optional: true },
-            { name: 'customAction', type: 'string', optional: true, /**
-                                                                     *
-                                                                     * @param val
-                                                                     * @param path
-                                                                     * @param errs
-                                                                     */
+            { name: 'customAction', type: 'string', optional: true,
+                /**
+                 * Validates the customAction string against a list of known custom actions.
+                 *
+                 * @param {string} val - The custom action string.
+                 * @param {string} path - The JSDoc path to the value.
+                 * @param {string[]} errs - Array to push error messages to.
+                 * @returns {boolean} True if valid.
+                 */
                 validator: (val, path, errs) => {
                     if (!validCustomActions.includes(val)) {
                         errs.push(`${path}: Invalid customAction "${val}". Expected one of ${validCustomActions.join(', ')}.`);
@@ -797,12 +854,16 @@ export function validateAutoModConfig(autoModConfig, actionProfiles) {
         const ruleSetContext = `${context}.automodRuleSets[${index}]`;
 
         const ruleSetFieldDefs = [
-            { name: 'checkType', type: 'string', /**
-                                                  *
-                                                  * @param val
-                                                  * @param path
-                                                  * @param errs
-                                                  */
+            { name: 'checkType', type: 'string',
+                /**
+                 * Validates the checkType string.
+                 * Ensures it's camelCase or a known actionProfile name.
+                 *
+                 * @param {string} val - The checkType string.
+                 * @param {string} path - The JSDoc path to the value.
+                 * @param {string[]} errs - Array to push error messages to.
+                 * @returns {boolean} True (as errors are pushed directly).
+                 */
                 validator: (val, path, errs) => {
                 // A checkType in automodConfig might not necessarily have a direct 1:1 actionProfile
                 // if it's a more abstract grouping or if actionProfiles are fine-grained.
@@ -831,12 +892,15 @@ export function validateAutoModConfig(autoModConfig, actionProfiles) {
                 const tierContext = `${ruleSetContext}.tiers[${tierIndex}]`;
                 const tierFieldDefs = [
                     { name: 'flagThreshold', type: 'positiveNumber' },
-                    { name: 'actionType', type: 'string', /**
-                                                           *
-                                                           * @param val
-                                                           * @param path
-                                                           * @param errs
-                                                           */
+                    { name: 'actionType', type: 'string',
+                        /**
+                         * Validates the AutoMod actionType string.
+                         *
+                         * @param {string} val - The actionType string.
+                         * @param {string} path - The JSDoc path to the value.
+                         * @param {string[]} errs - Array to push error messages to.
+                         * @returns {boolean} True if valid.
+                         */
                         validator: (val, path, errs) => {
                             if (!validAutoModActions.includes(val)) {
                                 errs.push(`${path}: Invalid actionType "${val}". Expected one of ${validAutoModActions.join(', ')}.`);
@@ -962,12 +1026,16 @@ export function validateRanksConfig(ranksConfig, mainConfigOwnerName, mainConfig
         const rankDefContext = `${rdContext}[${index}]`;
 
         const rankDefFields = [
-            { name: 'id', type: 'string', /**
-                                           *
-                                           * @param val
-                                           * @param path
-                                           * @param errs
-                                           */
+            { name: 'id', type: 'string',
+                /**
+                 * Validates the rank ID.
+                 * Ensures it is lowercase and unique.
+                 *
+                 * @param {string} val - The rank ID.
+                 * @param {string} path - The JSDoc path to the value.
+                 * @param {string[]} errs - Array to push error messages to.
+                 * @returns {boolean} True (as errors are pushed directly).
+                 */
                 validator: (val, path, errs) => {
                     if (val !== val.toLowerCase()) {
                         errs.push(`${path}: Rank ID "${val}" must be lowercase.`);
@@ -988,12 +1056,16 @@ export function validateRanksConfig(ranksConfig, mainConfigOwnerName, mainConfig
             ] },
             { name: 'nametagPrefix', type: 'string', optional: true },
             { name: 'conditions', type: 'array' },
-            { name: 'priority', type: 'number', /**
-                                                 *
-                                                 * @param val
-                                                 * @param path
-                                                 * @param errs
-                                                 */
+            { name: 'priority', type: 'number',
+                /**
+                 * Validates the rank priority.
+                 * Ensures it is unique.
+                 *
+                 * @param {number} val - The priority value.
+                 * @param {string} path - The JSDoc path to the value.
+                 * @param {string[]} errs - Array to push error messages to.
+                 * @returns {boolean} True (as errors are pushed directly).
+                 */
                 validator: (val, path, errs) => {
                     if (rankPriorities.has(val)) {
                         errs.push(`${path}: Duplicate priority ${val} found. Priorities must be unique.`);
@@ -1013,12 +1085,15 @@ export function validateRanksConfig(ranksConfig, mainConfigOwnerName, mainConfig
                 const condContext = `${rankDefContext}.conditions[${condIndex}]`;
                 const validConditionTypes = ['ownerName', 'adminTag', 'manualTagPrefix', 'tag', 'default'];
                 const conditionFieldDefs = [
-                    { name: 'type', type: 'string', /**
-                                                     *
-                                                     * @param val
-                                                     * @param path
-                                                     * @param errs
-                                                     */
+                    { name: 'type', type: 'string',
+                        /**
+                         * Validates the rank condition type string.
+                         *
+                         * @param {string} val - The condition type string.
+                         * @param {string} path - The JSDoc path to the value.
+                         * @param {string[]} errs - Array to push error messages to.
+                         * @returns {boolean} True if valid.
+                         */
                         validator: (val, path, errs) => {
                             if (!validConditionTypes.includes(val)) {
                                 errs.push(`${path}: Invalid condition type "${val}". Expected one of ${validConditionTypes.join(', ')}.`);

--- a/AntiCheatsBP/scripts/core/rankManager.js
+++ b/AntiCheatsBP/scripts/core/rankManager.js
@@ -8,8 +8,7 @@ import { rankDefinitions, defaultChatFormatting, defaultNametagPrefix, defaultPe
 /**
  * @description Dynamically generated mapping of rank IDs (lowerCase) to their numeric permission levels.
  * Populated by `initializeRanks`.
- * @export
- * @type {Object.<string, number>}
+ * @type {{[key: string]: number}}
  */
 export let permissionLevels = {};
 
@@ -71,8 +70,8 @@ function initializeRankSystem(dependencies) {
  * @param {import('@minecraft/server').Player} player - The player instance.
  * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
  * @returns {{ rankDefinition: import('./ranksConfig.js').RankDefinition | null, permissionLevel: number, rankId: string | null }}
- *          Object containing matched rank definition, permission level, and rank ID (lowerCase).
- *          Returns default/member level if no specific rank matches.
+ * Object containing matched rank definition, permission level, and rank ID (lowerCase).
+ * Returns default/member level if no specific rank matches.
  */
 function getPlayerRankAndPermissions(player, dependencies) {
     const { config, playerUtils } = dependencies; // Removed getString
@@ -284,9 +283,9 @@ export function getRankById(rankId) {
  * @param {string} actionContext - A string describing the action (e.g., 'ban', 'kick', 'mute') for logging/messaging.
  * @param {import('../types.js').Dependencies} dependencies - Standard dependencies object.
  * @returns {{allowed: boolean, messageKey?: string, messageParams?: Record<string, string>}}
- *          `allowed` is true if permission is granted.
- *          If false, `messageKey` provides a textDatabase key for the denial reason,
- *          and `messageParams` provides parameters for that message.
+ * `allowed` is true if permission is granted.
+ * If false, `messageKey` provides a textDatabase key for the denial reason,
+ * and `messageParams` provides parameters for that message.
  */
 export function canAdminActionTarget(issuerPlayer, targetPlayer, actionContext, dependencies) {
     const { playerUtils, permissionLevels: depPermLevels } = dependencies; // Removed getString, assuming getString is part of playerUtils or top-level in dependencies

--- a/AntiCheatsBP/scripts/core/ranksConfig.js
+++ b/AntiCheatsBP/scripts/core/ranksConfig.js
@@ -17,11 +17,11 @@
 /**
  * @typedef {object} RankCondition
  * @property {('ownerName'|'adminTag'|'manualTagPrefix'|'tag'|'default')} type - The type of condition (camelCase).
- *      - `ownerName`: Matches if player's nameTag equals `config.ownerPlayerName`.
- *      - `adminTag`: Matches if player has the tag specified in `config.adminTag`.
- *      - `manualTagPrefix`: Matches if player has a tag like `prefix` + `rankId` (e.g., 'rank_vip').
- *      - `tag`: Matches if player has the specified `tag` string.
- *      - `default`: A fallback condition, usually for the 'member' rank.
+ * - `ownerName`: Matches if player's nameTag equals `config.ownerPlayerName`.
+ * - `adminTag`: Matches if player has the tag specified in `config.adminTag`.
+ * - `manualTagPrefix`: Matches if player has a tag like `prefix` + `rankId` (e.g., 'rank_vip').
+ * - `tag`: Matches if player has the specified `tag` string.
+ * - `default`: A fallback condition, usually for the 'member' rank.
  * @property {string} [prefix] - Required if type is 'manualTagPrefix'. The prefix for the rank tag (e.g., 'rank_').
  * @property {string} [tag] - Required if type is 'tag'. The specific tag to check for.
  */
@@ -29,7 +29,7 @@
 /**
  * @typedef {object} RankDefinition
  * @property {string} id - Unique identifier for the rank (e.g., 'owner', 'admin', 'vip').
- *                        Should be `camelCase` or `lowercase`. It will be processed as lowercase by RankManager.
+ * Should be `camelCase` or `lowercase`. It will be processed as lowercase by RankManager.
  * @property {string} name - Display name for the rank (e.g., "Owner", "Administrator").
  * @property {number} permissionLevel - Numeric permission level. Lower is higher privilege (0 = Owner).
  * @property {ChatFormatting} [chatFormatting] - Optional chat formatting overrides.

--- a/AntiCheatsBP/scripts/core/uiManager.js
+++ b/AntiCheatsBP/scripts/core/uiManager.js
@@ -144,11 +144,12 @@ const PLAYER_ACTIONS_BTN_CLEAR_INV = 9;
 const PLAYER_ACTIONS_BTN_BACK_TO_LIST = 10;
 
 /**
+ * Displays a form with various actions that can be taken on a specific player.
  *
- * @param adminPlayer
- * @param targetPlayer
- * @param playerDataManager
- * @param dependencies
+ * @param {import('@minecraft/server').Player} adminPlayer - The admin player using the form.
+ * @param {import('@minecraft/server').Player} targetPlayer - The player being targeted by the actions.
+ * @param {import('../types.js').PlayerDataManagerFull} playerDataManager - The player data manager instance.
+ * @param {import('../types.js').Dependencies} dependencies - Standard command dependencies.
  */
 async function showPlayerActionsForm(adminPlayer, targetPlayer, playerDataManager, dependencies) {
     const { config, playerUtils, logManager, getString, commandExecutionMap } = dependencies; // Removed permissionLevels
@@ -205,8 +206,10 @@ async function showPlayerActionsForm(adminPlayer, targetPlayer, playerDataManage
         let shouldReturnToPlayerList = false;
         let shouldReturnToPlayerActions = true; // Default to re-showing this form
         /**
+         * Retrieves a command execution function from the command map.
          *
-         * @param cmd
+         * @param {string} cmd - The name of the command to retrieve.
+         * @returns {((player: import('@minecraft/server').Player, args: string[], dependencies: import('../types.js').Dependencies) => Promise<void>) | undefined} The command's execute function or undefined if not found.
          */
         const cmdExec = (cmd) => commandExecutionMap?.get(cmd);
 
@@ -342,10 +345,12 @@ const ADMIN_PANEL_BTN_CLOSE_WITH_OWNER_BUTTON = 6; // Index of close if owner bu
 
 
 /**
+ * Shows the main admin panel form.
+ * Displays different options based on the admin's permission level.
  *
- * @param player
- * @param playerDataManager
- * @param dependencies
+ * @param {import('@minecraft/server').Player} player - The player (admin) viewing the panel.
+ * @param {import('../types.js').PlayerDataManagerFull} playerDataManager - The player data manager instance.
+ * @param {import('../types.js').Dependencies} dependencies - Standard command dependencies.
  */
 async function showAdminPanelMain(player, playerDataManager, dependencies) {
     const { playerUtils, logManager, getString, permissionLevels, rankManager } = dependencies; // uiManager removed as functions are called directly
@@ -423,9 +428,11 @@ async function showAdminPanelMain(player, playerDataManager, dependencies) {
 };
 
 /**
+ * Shows a form listing all currently online players.
+ * Allows selecting a player to view further actions.
  *
- * @param adminPlayer
- * @param dependencies
+ * @param {import('@minecraft/server').Player} adminPlayer - The admin player viewing the list.
+ * @param {import('../types.js').Dependencies} dependencies - Standard command dependencies.
  */
 async function showOnlinePlayersList(adminPlayer, dependencies) {
     const { playerUtils, logManager, playerDataManager, getString, mc: minecraft } = dependencies; // Removed uiManager
@@ -494,10 +501,11 @@ async function showOnlinePlayersList(adminPlayer, dependencies) {
 // async function showServerManagementForm (_adminPlayer, _playerDataManager_unused, _config_unused, _dependencies) { /* ... */ };
 // async function showModLogTypeSelectionForm (_adminPlayer, _dependencies, _currentFilterName = null) { /* ... */ };
 /**
+ * Shows a form displaying detailed flags for a specific target player. (Currently a stub)
  *
- * @param adminPlayer
- * @param targetPlayer
- * @param dependencies
+ * @param {import('@minecraft/server').Player} adminPlayer - The admin player viewing the flags.
+ * @param {import('@minecraft/server').Player} targetPlayer - The player whose flags are being viewed.
+ * @param {import('../types.js').Dependencies} dependencies - Standard command dependencies.
  */
 async function showDetailedFlagsForm (adminPlayer, targetPlayer, dependencies) {
     const { playerUtils, getString, playerDataManager } = dependencies;
@@ -509,9 +517,10 @@ async function showDetailedFlagsForm (adminPlayer, targetPlayer, dependencies) {
 };
 
 /**
+ * Shows a form for resetting flags for a player. (Currently a stub)
  *
- * @param player
- * @param dependencies
+ * @param {import('@minecraft/server').Player} player - The admin player initiating the action.
+ * @param {import('../types.js').Dependencies} dependencies - Standard command dependencies.
  */
 async function showResetFlagsForm(player, dependencies) {
     const { playerUtils, getString, playerDataManager } = dependencies;
@@ -521,9 +530,10 @@ async function showResetFlagsForm(player, dependencies) {
 }
 
 /**
+ * Shows a list of watched players. (Currently a stub)
  *
- * @param player
- * @param dependencies
+ * @param {import('@minecraft/server').Player} player - The admin player viewing the list.
+ * @param {import('../types.js').Dependencies} dependencies - Standard command dependencies.
  */
 async function showWatchedPlayersList(player, dependencies) {
     const { playerUtils, getString, playerDataManager } = dependencies;
@@ -533,9 +543,10 @@ async function showWatchedPlayersList(player, dependencies) {
 }
 
 /**
+ * Shows a server management form. (Currently a stub)
  *
- * @param player
- * @param dependencies
+ * @param {import('@minecraft/server').Player} player - The admin player using the form.
+ * @param {import('../types.js').Dependencies} dependencies - Standard command dependencies.
  */
 async function showServerManagementForm(player, dependencies) {
     const { playerUtils, getString, playerDataManager } = dependencies;
@@ -545,9 +556,10 @@ async function showServerManagementForm(player, dependencies) {
 }
 
 /**
+ * Shows a form for editing configuration values. (Currently a stub)
  *
- * @param player
- * @param dependencies
+ * @param {import('@minecraft/server').Player} player - The admin player (owner) using the form.
+ * @param {import('../types.js').Dependencies} dependencies - Standard command dependencies.
  */
 async function showEditConfigForm(player, dependencies) {
     const { playerUtils, getString, playerDataManager } = dependencies;
@@ -557,9 +569,10 @@ async function showEditConfigForm(player, dependencies) {
 }
 
 /**
+ * Shows the main panel for normal users. (Currently a stub)
  *
- * @param player
- * @param dependencies
+ * @param {import('@minecraft/server').Player} player - The player viewing the panel.
+ * @param {import('../types.js').Dependencies} dependencies - Standard command dependencies.
  */
 function showNormalUserPanelMain(player, dependencies) { // Removed async
     const { playerUtils, getString, playerDataManager: _playerDataManager } = dependencies; // Prefixed playerDataManager

--- a/AntiCheatsBP/scripts/types.js
+++ b/AntiCheatsBP/scripts/types.js
@@ -123,8 +123,8 @@
  * @property {PlayerBanInfo | null} [banInfo] Current ban status. Persisted.
  * @property {PlayerFlagData} flags Accumulated violation flags.
  * @property {string} [lastFlagType] The `checkType` of the most recent flag.
- * @property {Object.<string, {itemTypeId?: string, quantityFound?: number, timestamp: number, details?: string, [key: string]: any}>} [lastViolationDetailsMap] Stores details of the last violation for specific check types. Persisted.
- * @property {Object.<string, {lastActionThreshold?: number, lastActionTimestamp?: number, [key: string]: any}>} [automodState] State information for the AutoMod system related to this player. Persisted.
+ * @property {{[key: string]: {itemTypeId?: string, quantityFound?: number, timestamp: number, details?: string, [key: string]: any}}} [lastViolationDetailsMap] Stores details of the last violation for specific check types. Persisted.
+ * @property {{[key: string]: {lastActionThreshold?: number, lastActionTimestamp?: number, [key: string]: any}}} [automodState] State information for the AutoMod system related to this player. Persisted.
  * @property {number} [lastLoginTime] Timestamp of the last login.
  * @property {number} [lastLogoutTime] Timestamp of the last logout.
  * @property {number} [joinCount=0] Total number of times the player has joined.
@@ -159,7 +159,7 @@
  * @property {boolean} [isChargingBow=false] True if currently charging a bow/crossbow.
  * @property {boolean} [isUsingShield=false] True if currently holding up/using a shield.
  * @property {number} [lastItemUseTick=0] Game tick of the last significant item use start.
- * @property {Object.<string, number>} [itemUseTimestamps] Timestamps of last use for specific items (for FastUse check).
+ * @property {{[key: string]: number}} [itemUseTimestamps] Timestamps of last use for specific items (for FastUse check).
  *
  * World Interaction / Building State:
  * @property {number[]} [blockBreakEventsTimestamps] Timestamps of recent block break actions (for Nuker).
@@ -487,6 +487,11 @@
  * @typedef {object} EventSpecificData
  */
 
+/**
+ * @typedef {object} SoundOptions
+ * @property {number} volume
+ * @property {number} pitch
+ */
 
 // This line is important to make this file a module and allow JSDoc types to be imported globally by other files.
 /**

--- a/AntiCheatsBP/scripts/utils/playerUtils.js
+++ b/AntiCheatsBP/scripts/utils/playerUtils.js
@@ -316,8 +316,10 @@ export function playSoundForEvent(primaryPlayer, eventName, dependencies, target
     };
 
     /**
+     * Helper function to play a configured sound to a specific player instance.
+     * Includes error handling for `playSound`.
      *
-     * @param playerInstance
+     * @param {import('@minecraft/server').Player} playerInstance - The player to play the sound for.
      */
     const playToPlayer = (playerInstance) => {
         if (playerInstance?.isValid()) {


### PR DESCRIPTION
- Added missing JSDoc parameter types, descriptions, and return types across multiple files, primarily in `configValidator.js` and `uiManager.js`.
- Corrected `jsdoc/check-types` errors by replacing generic `Object` with specific object shorthand or typedefs.
- Fixed various `jsdoc/check-indentation` warnings related to multi-line descriptions.
- Addressed `jsdoc/tag-lines` warnings by ensuring correct newlines between descriptions and tags.
- Resolved an invalid `jsdoc/check-tag-names` error.
- Allowed `eslint --fix` to correct core `indent` issues and other auto-fixable warnings.

Significant reduction in linting problems from 282 to 30. Some stubborn or complex issues remain for future attention.