### PR TITLE
style: Apply ESLint fixes for JSDoc, style, and minor issues

### DIFF
--- a/AntiCheatsBP/scripts/config.js
+++ b/AntiCheatsBP/scripts/config.js
@@ -809,16 +809,13 @@ export const editableConfigValues = { ...defaultConfigSettings };
 /**
  * Updates a configuration value at runtime.
  * Performs type checking and coercion for basic types (string, number, boolean).
- *
  * For array and object types, if the input `value` is a JSON string, it will be parsed
  * and will fully replace the existing array/object. This function does not support
  * partial updates (e.g., adding an element to an array or modifying a single property
  * of an object via a partial JSON string).
- *
  * If more sophisticated partial updates or validation for nested structures within
  * complex types (arrays/objects) are needed in the future, this function would
  * require significant enhancement.
- *
  * @param {string} key - The configuration key to update (must exist in `defaultConfigSettings` and `editableConfigValues`).
  * @param {unknown} value - The new value for the configuration key. If `key` corresponds to an array or object,
  *                        `value` can be the new array/object directly, or a JSON string representation.

--- a/AntiCheatsBP/scripts/core/actionManager.js
+++ b/AntiCheatsBP/scripts/core/actionManager.js
@@ -148,10 +148,9 @@ export async function executeCheckAction(player, checkType, violationDetails, de
     // Use the re-fetched pData (pDataAfterAwait) for lastViolationDetailsMap update
     // This block should only execute if player was valid and pDataAfterAwait was successfully fetched.
     if (player && player.isValid() && violationDetails && Object.keys(violationDetails).length > 0) {
-        const pDataToUseForMap = playerDataManager?.getPlayerData(player.id); // Re-fetch to ensure latest state, or use pDataAfterAwait if it was confirmed valid
-                                                                            // Using a fresh fetch here to be absolutely certain after all awaits.
-                                                                            // However, if pDataAfterAwait from above is sufficient and confirmed valid, it can be reused.
-                                                                            // For maximum safety in this specific update:
+        // Using a fresh fetch here to be absolutely certain after all awaits.
+        // However, if pDataAfterAwait from above is sufficient and confirmed valid, it can be reused.
+        // For maximum safety in this specific update:
         const currentPData = playerDataManager?.getPlayerData(player.id);
         if (currentPData) {
             currentPData.lastViolationDetailsMap ??= {};
@@ -170,7 +169,7 @@ export async function executeCheckAction(player, checkType, violationDetails, de
             currentPData.isDirtyForSave = true;
             playerUtils?.debugLog(`[ActionManager.executeCheckAction] Stored violation details for check '${checkType}' for ${playerNameForLog}: ${JSON.stringify(detailsToStore)}`, player?.nameTag, dependencies);
         } else { // Player is valid, but pData is null (should be rare if player just interacted)
-             playerUtils?.debugLog(`[ActionManager.executeCheckAction] Could not store violation details for '${checkType}' (pData not found for ${playerNameForLog} after await).`, player?.nameTag, dependencies);
+            playerUtils?.debugLog(`[ActionManager.executeCheckAction] Could not store violation details for '${checkType}' (pData not found for ${playerNameForLog} after await).`, player?.nameTag, dependencies);
         }
     } else if (player && !player.isValid() && violationDetails && Object.keys(violationDetails).length > 0) {
         playerUtils?.debugLog(`[ActionManager.executeCheckAction] Player ${playerNameForLog} became invalid. Skipping details map update.`, null, dependencies);

--- a/AntiCheatsBP/scripts/core/commandManager.js
+++ b/AntiCheatsBP/scripts/core/commandManager.js
@@ -225,8 +225,8 @@ export async function handleChatCommand(eventData, dependencies) {
                 meta: {
                     command: finalCommandName,
                     args: args.join(', '),
-                }
-            }
+                },
+            },
         }, dependencies);
         playerUtils?.playSoundForEvent(player, 'commandError', dependencies);
     }

--- a/AntiCheatsBP/scripts/core/eventHandlers.js
+++ b/AntiCheatsBP/scripts/core/eventHandlers.js
@@ -4,8 +4,8 @@
 // Let's assume `dependencies.profilingData` and `dependencies.MAX_PROFILING_HISTORY` will be available.
 
 /**
- * @module AntiCheatsBP/scripts/core/eventHandlers
  * Wraps an event handler function with profiling logic.
+ * @module AntiCheatsBP/scripts/core/eventHandlers
  * @param {string} handlerName - The name of the event handler for logging.
  * @param {Function} handlerFunction - The actual event handler function.
  * @returns {Function} - The wrapped event handler function.
@@ -285,7 +285,9 @@ async function _handlePlayerSpawn(eventData, dependencies) {
         if (checks?.checkInvalidRenderDistance && config.enableInvalidRenderDistanceCheck) {
             // Initial render distance check might be useful on spawn
             minecraftSystem.system.runTimeout(async () => {
-                if (!player.isValid()) return;
+                if (!player.isValid()) {
+                    return;
+                }
                 const currentPData = playerDataManager.getPlayerData(player.id); // Re-fetch pData inside timeout
                 if (!currentPData) {
                     playerUtils?.debugLog(`[EvtHdlr.Spawn.Timeout.checkInvalidRenderDistance] pData not found for ${playerName}.`, playerName, dependencies);
@@ -317,9 +319,9 @@ async function _handlePlayerSpawn(eventData, dependencies) {
                 message: error.message,
                 rawErrorStack: error.stack,
                 meta: {
-                    initialSpawn: initialSpawn,
-                }
-            }
+                    initialSpawn,
+                },
+            },
         }, dependencies);
     }
 }
@@ -421,9 +423,13 @@ async function _handleEntitySpawnEventAntiGrief(eventData, dependencies) {
                     const isSpam = await checks.checkEntitySpam(player, entity.typeId, pData, dependencies);
 
                     // Re-fetch pData for this player after the await before modifying it
-                    if (!player.isValid()) break; // Player might have disconnected during await
+                    if (!player.isValid()) {
+                        break;
+                    } // Player might have disconnected during await
                     const currentPDataForLoop = playerDataManager?.getPlayerData(player.id);
-                    if (!currentPDataForLoop) break; // pData might be gone
+                    if (!currentPDataForLoop) {
+                        break;
+                    } // pData might be gone
 
                     if (isSpam && config.entitySpamAction === 'kill') {
                         try {
@@ -445,7 +451,7 @@ async function _handleEntitySpawnEventAntiGrief(eventData, dependencies) {
                     currentPDataForLoop.expectingConstructedEntity = null; // Clear expectation on the potentially re-fetched pData
                     currentPDataForLoop.isDirtyForSave = true;
                 } else {
-                     // If checkEntitySpam doesn't exist, still clear expectation on original pData
+                    // If checkEntitySpam doesn't exist, still clear expectation on original pData
                     pData.expectingConstructedEntity = null;
                     pData.isDirtyForSave = true;
                 }
@@ -825,7 +831,9 @@ async function _handlePlayerBreakBlockBeforeEvent(eventData, dependencies) {
     // If not cancelled by checkBreakUnbreakable
     if (!eventData.cancel) {
         // Re-fetch pData after await checkBreakUnbreakable
-        if (!player.isValid()) return;
+        if (!player.isValid()) {
+            return;
+        }
         const currentPData = playerDataManager?.getPlayerData(player.id);
         if (!currentPData) {
             dependencies.playerUtils?.debugLog(`[EvtHdlr.BreakBlockBefore] pData not found for ${player.nameTag} after unbreakable check.`, player.nameTag, dependencies);
@@ -889,7 +897,9 @@ async function _handlePlayerBreakBlockAfterEvent(eventData, dependencies) {
     }
 
     // Re-fetch pData after all await calls before modifying it.
-    if (!player.isValid()) return;
+    if (!player.isValid()) {
+        return;
+    }
     const finalPData = playerDataManager?.getPlayerData(player.id);
     if (!finalPData) {
         dependencies.playerUtils?.debugLog(`[EvtHdlr.BreakBlockAfter] pData not found for ${player.nameTag} at end of handler.`, player.nameTag, dependencies);
@@ -1260,7 +1270,7 @@ async function _handlePlayerDimensionChangeAfterEvent(eventData, dependencies) {
     }
 
     // Update pData with new dimension
-    let pData = pdm?.getPlayerData(player.id);
+    const pData = pdm?.getPlayerData(player.id);
     if (pData) {
         pData.lastDimensionId = toDimension.id;
         pData.isDirtyForSave = true;
@@ -1299,7 +1309,9 @@ async function _handlePlayerDimensionChangeAfterEvent(eventData, dependencies) {
             playerUtils?.warnPlayer(player, getString('dimensionLock.teleportMessage', { lockedDimensionName }));
 
             // Re-fetch pData before using it for notifyAdmins, as player.teleport was awaited
-            if (!player.isValid()) return; // Player might have disconnected during teleport attempt
+            if (!player.isValid()) {
+                return;
+            } // Player might have disconnected during teleport attempt
             const currentPData = pdm?.getPlayerData(player.id);
             // pData for notifyAdmins context can be the currentPData or null if not found
 

--- a/AntiCheatsBP/scripts/core/logManager.js
+++ b/AntiCheatsBP/scripts/core/logManager.js
@@ -70,21 +70,19 @@ export function persistLogCacheToDisk(dependencies) {
  * Adds a new log entry to the in-memory cache and marks logs as dirty.
  * Manages log rotation to stay within `maxLogEntriesCount`.
  * Ensures `actionType` uses `camelCase`.
- *
  * Standard for Error Log Entries:
  * When logging errors (e.g., actionType starts with 'error.' or is 'system_error'), the `details` object
  * within the `LogEntry` should follow this structure for consistency and better analysis:
  * ```
  * details: {
- *   errorCode: string,    // REQUIRED: A unique, short, UPPER_SNAKE_CASE string code (e.g., 'PDM_DP_DATA_PARSE_FAIL', 'CMD_EXEC_FAIL').
- *   message: string,      // REQUIRED: The primary error message (usually error.message).
- *   rawErrorStack?: string, // OPTIONAL (but recommended): The full stack trace (error.stack).
- *   meta?: object          // OPTIONAL: An object for any other context-specific key-value pairs relevant to this specific error.
+ * errorCode: string,    // REQUIRED: A unique, short, UPPER_SNAKE_CASE string code (e.g., 'PDM_DP_DATA_PARSE_FAIL', 'CMD_EXEC_FAIL').
+ * message: string,      // REQUIRED: The primary error message (usually error.message).
+ * rawErrorStack?: string, // OPTIONAL (but recommended): The full stack trace (error.stack).
+ * meta?: object          // OPTIONAL: An object for any other context-specific key-value pairs relevant to this specific error.
  * }
  * ```
  * The `actionType` for errors should also follow a pattern like `error.<module>.<optional_sub_context>` (e.g., `error.pdm.dp`, `error.cmd.exec`).
  * The main `LogEntry.context` string should still provide the specific function/module path where the error originated.
- *
  * @param {import('../types.js').LogEntry} logEntry - The log entry object. Must contain `actionType`. `timestamp` and `adminName` default if not provided.
  * @param {import('../types.js').CommandDependencies} dependencies - Standard dependencies object.
  */

--- a/AntiCheatsBP/scripts/core/playerDataManager.js
+++ b/AntiCheatsBP/scripts/core/playerDataManager.js
@@ -133,24 +133,31 @@ function _handleDynamicPropertyError(callingFunction, operation, playerName, err
     const logContext = `playerDataManager.${callingFunction}`;
 
     let opType = 'unknown';
-    if (operation.toLowerCase().includes('json.parse')) opType = 'parse';
-    else if (operation.toLowerCase().includes('json.stringify')) opType = 'stringify';
-    else if (operation.toLowerCase().includes('getdynamicproperty')) opType = 'get'; // Made lowercase for robust matching
-    else if (operation.toLowerCase().includes('setdynamicproperty')) opType = 'set'; // Made lowercase
+    if (operation.toLowerCase().includes('json.parse')) {
+        opType = 'parse';
+    } else if (operation.toLowerCase().includes('json.stringify')) {
+        opType = 'stringify';
+    } else if (operation.toLowerCase().includes('getdynamicproperty')) {
+        opType = 'get';
+    } // Made lowercase for robust matching
+    else if (operation.toLowerCase().includes('setdynamicproperty')) {
+        opType = 'set';
+    } // Made lowercase
 
-    let contextStr = 'unknown';
-    if (callingFunction === 'savePlayerDataToDynamicProperties' || callingFunction === 'loadPlayerDataFromDynamicProperties') {
-        contextStr = 'data';
-    }
     // Add more contexts here if _handleDynamicPropertyError is used by other functions for different DP keys.
 
     // Refined actionType and errorCode to match new standardization
     const actionTypePrefix = 'error.pdm.dp';
     let specificErrorType = opType; // 'parse', 'stringify', 'get', 'set'
-    if (opType === 'get') specificErrorType = 'Get';
-    else if (opType === 'set') specificErrorType = 'Set';
-    else if (opType === 'parse') specificErrorType = 'Parse';
-    else if (opType === 'stringify') specificErrorType = 'Stringify';
+    if (opType === 'get') {
+        specificErrorType = 'Get';
+    } else if (opType === 'set') {
+        specificErrorType = 'Set';
+    } else if (opType === 'parse') {
+        specificErrorType = 'Parse';
+    } else if (opType === 'stringify') {
+        specificErrorType = 'Stringify';
+    }
 
 
     const newActionType = `${actionTypePrefix}${specificErrorType}`; // e.g., error.pdm.dpGet, error.pdm.dpParse
@@ -161,14 +168,14 @@ function _handleDynamicPropertyError(callingFunction, operation, playerName, err
         context: logContext,    // e.g., playerDataManager.loadPlayerDataFromDynamicProperties
         targetName: playerName,
         details: {
-            errorCode: errorCode,
+            errorCode,
             message: error.message,
             rawErrorStack: error.stack,
             meta: {
                 originalOperation: operation, // Keep original 'operation' for specific detail
                 callingFunctionContext: callingFunction, // Keep original 'callingFunction' for specific detail
                 ...additionalDetails,
-            }
+            },
         },
     }, dependencies);
 }
@@ -495,7 +502,7 @@ export async function ensurePlayerDataInitialized(player, dependencies) {
         // If ensurePlayerDataInitialized is called mid-session (e.g. script reload, player already online),
         // loadedData.joinTime would be correct for *that* session start.
         newPData.joinTime = loadedData.joinTime ?? newPData.joinTime; // Keep what initializeDefaultPlayerData set if not in loadedData
-                                                                    // or what was loaded. handlePlayerSpawn will update if it's a true new session.
+        // or what was loaded. handlePlayerSpawn will update if it's a true new session.
 
         // firstEverLoginTime should only be set once. If it's in loadedData, use that.
         // Otherwise, initializeDefaultPlayerData already set it to Date.now().

--- a/AntiCheatsBP/scripts/utils/itemUtils.js
+++ b/AntiCheatsBP/scripts/utils/itemUtils.js
@@ -1,8 +1,4 @@
 /**
- * @file Provides utility functions related to items, blocks, and their interactions,
- * primarily for calculating block breaking speeds and determining optimal tools.
- * Includes simplified models for game mechanics like block hardness and tool effectiveness.
- *
  * IMPORTANT: This module is a server-side approximation of complex client-side game mechanics.
  * It is intended for use in contexts where exact client-side behavior is not critical
  * but a reasonable estimation is needed for server-side logic (e.g., anti-cheat checks).
@@ -18,7 +14,9 @@
  * block breaking mechanics. Any updates to the game that alter how block hardness,
  * tool speeds, enchantments, or player effects interact will likely necessitate
  * modifications to this file to maintain reasonable accuracy.
- *
+ * @file Provides utility functions related to items, blocks, and their interactions,
+ * primarily for calculating block breaking speeds and determining optimal tools.
+ * Includes simplified models for game mechanics like block hardness and tool effectiveness.
  * @module AntiCheatsBP/scripts/utils/itemUtils
  */
 import * as mc from '@minecraft/server';


### PR DESCRIPTION
Applied various ESLint fixes across the codebase, including:
- Corrected JSDoc parameter types, order, and descriptions.
- Removed unused variables and preferred const where applicable.
- Resolved brace-style, indentation, and comma-dangle issues.
- Fixed jsdoc/tag-lines warnings related to spacing in JSDoc blocks.

A persistent brace-style error in AntiCheatsBP/scripts/core/playerDataManager.js remains and has been noted for future investigation.