### PR TITLE
Refactor: Move command descriptions and usage strings to modules

### DIFF
--- a/AntiCheatsBP/scripts/commands/addrank.js
+++ b/AntiCheatsBP/scripts/commands/addrank.js
@@ -23,9 +23,10 @@ export async function execute(player, args, dependencies) {
     const { config, playerUtils, logManager, rankManager, getString } = dependencies;
     const adminName = player?.nameTag ?? 'UnknownAdmin';
     const prefix = config?.prefix ?? '!';
+    const usageMessage = `§cUsage: ${prefix}addrank <playername> <rankId>`;
 
     if (args.length < 2) {
-        player?.sendMessage(getString('command.addrank.usage', { prefix }));
+        player?.sendMessage(usageMessage);
         return;
     }
 

--- a/AntiCheatsBP/scripts/commands/ban.js
+++ b/AntiCheatsBP/scripts/commands/ban.js
@@ -33,13 +33,13 @@ export function execute(
     const { config, playerUtils, playerDataManager, logManager, rankManager, getString } = dependencies;
     const issuerName = player?.nameTag ?? (invokedBy === 'AutoMod' ? 'AutoMod' : 'System');
     const prefix = config?.prefix ?? '!';
+    const usageMessage = `§cUsage: ${prefix}ban <playername> [duration] [reason]`;
 
     const parsedArgs = playerUtils.parsePlayerAndReasonArgs(args, 2, 'command.ban.defaultReason', dependencies);
     const targetPlayerName = parsedArgs.targetPlayerName;
     let reason = parsedArgs.reason;
 
     if (!targetPlayerName) {
-        const usageMessage = getString('command.ban.usage', { prefix });
         if (player) {
             player.sendMessage(usageMessage);
         } else {

--- a/AntiCheatsBP/scripts/commands/clearreports.js
+++ b/AntiCheatsBP/scripts/commands/clearreports.js
@@ -26,10 +26,12 @@ export function execute(player, args, dependencies) {
     const { config, playerUtils, logManager, getString } = dependencies;
     const adminName = player?.nameTag ?? 'UnknownAdmin';
     const prefix = config?.prefix ?? '!';
+    const usageMessage = `§cUsage: ${prefix}${definition.syntax}`;
+    const exampleMessage = `§cExample: ${prefix}clearreports <report_id> OR ${prefix}clearreports <player_name> OR ${prefix}clearreports all`;
 
     if (args.length < 1) {
-        playerUtils?.sendMessage(player, getString('command.clearreports.usage', { prefix, syntax: definition.syntax }));
-        playerUtils?.sendMessage(player, getString('command.clearreports.example', { prefix }));
+        playerUtils?.sendMessage(player, usageMessage);
+        playerUtils?.sendMessage(player, exampleMessage);
         return;
     }
 

--- a/AntiCheatsBP/scripts/commands/copyinv.js
+++ b/AntiCheatsBP/scripts/commands/copyinv.js
@@ -28,9 +28,10 @@ export async function execute(player, args, dependencies) {
     const { config, playerUtils, logManager, playerDataManager, getString } = dependencies;
     const adminName = player?.nameTag ?? 'UnknownAdmin';
     const prefix = config?.prefix ?? '!';
+    const usageMessage = `§cUsage: ${prefix}copyinv <playername>`;
 
     if (args.length < 1) {
-        player?.sendMessage(getString('command.copyinv.usage', { prefix }));
+        player?.sendMessage(usageMessage);
         return;
     }
 

--- a/AntiCheatsBP/scripts/commands/endlock.js
+++ b/AntiCheatsBP/scripts/commands/endlock.js
@@ -76,7 +76,7 @@ export function execute(player, args, dependencies) {
                 break;
             }
             default:
-                player?.sendMessage(getString('command.endlock.usage', { prefix }));
+                player?.sendMessage(`§cUsage: ${prefix}endlock <on|off|status>`);
 
         }
     } catch (error) {

--- a/AntiCheatsBP/scripts/commands/freeze.js
+++ b/AntiCheatsBP/scripts/commands/freeze.js
@@ -49,9 +49,9 @@ export function execute(
     const slownessAmplifier = config?.freezeSlownessAmplifier ?? DEFAULT_FREEZE_SLOWNESS_AMPLIFIER;
     const weaknessAmplifier = config?.freezeWeaknessAmplifier ?? DEFAULT_FREEZE_WEAKNESS_AMPLIFIER;
     const showParticles = config?.freezeShowParticles ?? false;
+    const usageMsg = `§cUsage: ${prefix}freeze <playername> [on|off|toggle|status]`;
 
     if (args.length < 1) {
-        const usageMsg = getString('command.freeze.usage', { prefix });
         if (player) {
             player.sendMessage(usageMsg);
         } else {

--- a/AntiCheatsBP/scripts/commands/inspect.js
+++ b/AntiCheatsBP/scripts/commands/inspect.js
@@ -24,9 +24,10 @@ export function execute(player, args, dependencies) {
     const { config, playerUtils, playerDataManager, logManager, getString } = dependencies;
     const adminName = player?.nameTag ?? 'UnknownAdmin';
     const prefix = config?.prefix ?? '!';
+    const usageMessage = `§cUsage: ${prefix}inspect <playername>`;
 
     if (args.length < 1) {
-        player.sendMessage(getString('command.inspect.usage', { prefix }));
+        player.sendMessage(usageMessage);
         return;
     }
 

--- a/AntiCheatsBP/scripts/commands/invsee.js
+++ b/AntiCheatsBP/scripts/commands/invsee.js
@@ -28,9 +28,10 @@ export async function execute(player, args, dependencies) {
     const { config, playerUtils, logManager, getString } = dependencies;
     const adminName = player?.nameTag ?? 'UnknownAdmin';
     const prefix = config?.prefix ?? '!';
+    const usageMessage = `§cUsage: ${prefix}invsee <playername>`;
 
     if (args.length < 1) {
-        player.sendMessage(getString('command.invsee.usage', { prefix }));
+        player.sendMessage(usageMessage);
         return;
     }
 

--- a/AntiCheatsBP/scripts/commands/kick.js
+++ b/AntiCheatsBP/scripts/commands/kick.js
@@ -52,9 +52,9 @@ export function execute(
         // For now, if programmaticReason is not used, AutoMod should ensure args[1] is the reason or it will take default.
         reason = parsedArgsUtil.reason;
     }
+    const usageMessage = `§cUsage: ${prefix}kick <playername> [reason]`;
 
     if (!targetPlayerName) {
-        const usageMessage = getString('command.kick.usage', { prefix });
         if (player) {
             player.sendMessage(usageMessage);
         } else {

--- a/AntiCheatsBP/scripts/commands/mute.js
+++ b/AntiCheatsBP/scripts/commands/mute.js
@@ -39,9 +39,9 @@ export function execute(
     const parsedArgs = playerUtils.parsePlayerAndReasonArgs(args, 2, 'command.mute.defaultReason', dependencies);
     const targetPlayerName = parsedArgs.targetPlayerName;
     let reason = parsedArgs.reason;
+    const usageMessage = `§cUsage: ${prefix}mute <playername> [duration] [reason]`;
 
     if (!targetPlayerName) {
-        const usageMessage = getString('command.mute.usage', { prefix });
         if (player) {
             player.sendMessage(usageMessage);
         } else {

--- a/AntiCheatsBP/scripts/commands/netherlock.js
+++ b/AntiCheatsBP/scripts/commands/netherlock.js
@@ -76,7 +76,7 @@ export function execute(player, args, dependencies) {
                 break;
             }
             default:
-                player?.sendMessage(getString('command.netherlock.usage', { prefix }));
+                player?.sendMessage(`§cUsage: ${prefix}netherlock <on|off|status>`);
 
         }
     } catch (error) {

--- a/AntiCheatsBP/scripts/commands/notify.js
+++ b/AntiCheatsBP/scripts/commands/notify.js
@@ -76,7 +76,7 @@ export function execute(player, args, dependencies) {
             return;
         }
         default:
-            player.sendMessage(getString('command.notify.usage', { prefix }));
+            player.sendMessage(`§cUsage: ${prefix}notify <on|off|toggle|status>`);
             return;
     }
 

--- a/AntiCheatsBP/scripts/commands/purgeflags.js
+++ b/AntiCheatsBP/scripts/commands/purgeflags.js
@@ -28,9 +28,10 @@ export async function execute(player, args, dependencies) {
     const { config, playerUtils, logManager, currentTick, getString } = dependencies; // Removed mc
     const adminName = player?.nameTag ?? 'UnknownAdmin';
     const prefix = config?.prefix ?? '!';
+    const usageMessage = `§cUsage: ${prefix}${definition.syntax}`;
 
     if (args.length < 1) {
-        playerUtils?.sendMessage(player, getString('command.purgeflags.usage', { prefix, syntax: definition.syntax }));
+        playerUtils?.sendMessage(player, usageMessage);
         return;
     }
 

--- a/AntiCheatsBP/scripts/commands/tpa.js
+++ b/AntiCheatsBP/scripts/commands/tpa.js
@@ -9,7 +9,7 @@ const DEFAULT_TPA_REQUEST_TIMEOUT_SECONDS = 60;
 export const definition = {
     name: 'tpa',
     syntax: '<playerName>',
-    description: 'Requests to teleport to another player. They must accept with !tpaccept.',
+    description: 'Requests to teleport to another player.',
     permissionLevel: 1024, // member
     enabled: true,
 };

--- a/AntiCheatsBP/scripts/commands/tpacancel.js
+++ b/AntiCheatsBP/scripts/commands/tpacancel.js
@@ -6,7 +6,7 @@
 export const definition = {
     name: 'tpacancel',
     syntax: '[playerName]',
-    description: 'Cancels your outgoing TPA request or declines an incoming one. If [playerName] is specified, cancels request with that player.',
+    description: 'Cancels or declines a TPA request.',
     aliases: ['tpc', 'tpadeny', 'tpcancel'],
     permissionLevel: 1024, // member
     enabled: true,

--- a/AntiCheatsBP/scripts/commands/tpaccept.js
+++ b/AntiCheatsBP/scripts/commands/tpaccept.js
@@ -5,7 +5,7 @@
 export const definition = {
     name: 'tpaccept',
     syntax: '[playerName]',
-    description: 'Accepts an incoming TPA request. If multiple, specify which player\'s request to accept.',
+    description: 'Accepts an incoming TPA request.',
     aliases: ['tpaa', 'tpaaccept'],
     permissionLevel: 1024, // member
     enabled: true,

--- a/AntiCheatsBP/scripts/commands/tpahere.js
+++ b/AntiCheatsBP/scripts/commands/tpahere.js
@@ -9,7 +9,7 @@ const DEFAULT_TPA_REQUEST_TIMEOUT_SECONDS = 60;
 export const definition = {
     name: 'tpahere',
     syntax: '<playerName>',
-    description: 'Requests another player to teleport to your location. They must accept with !tpaccept.',
+    description: 'Requests another player to teleport to you.',
     permissionLevel: 1024, // member
     enabled: true,
 };

--- a/AntiCheatsBP/scripts/commands/tpastatus.js
+++ b/AntiCheatsBP/scripts/commands/tpastatus.js
@@ -5,7 +5,7 @@
 export const definition = {
     name: 'tpastatus',
     syntax: '[on|off|status]',
-    description: 'Manages your TPA (Teleport Ask) request availability or checks current status.',
+    description: 'Manages your TPA request availability (on/off/status).',
     aliases: ['tps'],
     permissionLevel: 1024, // member
     enabled: true,

--- a/AntiCheatsBP/scripts/commands/unban.js
+++ b/AntiCheatsBP/scripts/commands/unban.js
@@ -5,7 +5,7 @@
 export const definition = {
     name: 'unban',
     syntax: '<playername>',
-    description: 'Unbans a player, allowing them to rejoin the server.',
+    description: 'Unbans a player.',
     aliases: ['ub'],
     permissionLevel: 1, // admin
     enabled: true,

--- a/AntiCheatsBP/scripts/commands/unmute.js
+++ b/AntiCheatsBP/scripts/commands/unmute.js
@@ -5,7 +5,7 @@
 export const definition = {
     name: 'unmute',
     syntax: '<playername>',
-    description: 'Unmutes a player, allowing them to send chat messages again.',
+    description: 'Unmutes a player, allowing them to chat.',
     aliases: ['um'],
     permissionLevel: 1, // admin
     enabled: true,

--- a/AntiCheatsBP/scripts/core/textDatabase.js
+++ b/AntiCheatsBP/scripts/core/textDatabase.js
@@ -300,16 +300,9 @@ export const stringDB = {
     'tpa.notify.actionBar.autoDeclined': '§e{playerName} is no longer accepting TPA requests; your request was automatically declined.',
 
     // --- Command Descriptions (for help command) ---
-    'command.tpa.description': 'Requests to teleport to another player.',
-    'command.tpacancel.description': 'Cancels or declines a TPA request.',
-    'command.tpaccept.description': 'Accepts an incoming TPA request.',
-    'command.tpahere.description': 'Requests another player to teleport to you.',
-    'command.tpastatus.description': 'Manages your TPA request availability (on/off/status).',
-    'command.unban.description': 'Unbans a player.',
-    'command.unmute.description': 'Unmutes a player, allowing them to chat.',
+    // Descriptions are now directly in command definition files.
 
     // Command specific: addrank
-    'command.addrank.usage': '§cUsage: {prefix}addrank <playername> <rankId>',
     'command.addrank.playerNotFound': '§cPlayer \'{playerName}\' not found.',
     'command.addrank.rankIdInvalid': '§cRank ID \'{rankId}\' is not a valid rank.',
     'command.addrank.rankNotManuallyAssignable': '§cRank \'{rankName}\' cannot be assigned using this command (not configured for manual tag assignment).',
@@ -320,7 +313,6 @@ export const stringDB = {
     'command.addrank.errorAssign': '§cAn error occurred while assigning the rank: {errorMessage}',
 
     // Command specific: ban
-    'command.ban.usage': '§cUsage: {prefix}ban <playername> [duration] [reason]',
     'command.ban.playerNotFound': '§cPlayer \'{playerName}\' not found.',
     'command.ban.cannotBanSelf': '§cYou cannot ban yourself.',
     'command.ban.permissionDeniedAdminOwner': '§cYou do not have permission to ban an admin or owner.',
@@ -340,8 +332,6 @@ export const stringDB = {
     'command.clearchat.success': '§aChat cleared successfully.',
 
     // Command specific: clearreports
-    'command.clearreports.usage': '§cUsage: {prefix}{syntax}',
-    'command.clearreports.example': '§cExample: {prefix}clearreports <report_id> OR {prefix}clearreports <player_name> OR {prefix}clearreports all',
     'command.clearreports.allSuccess': '§aSuccessfully cleared all {count} reports.',
     'command.clearreports.idSuccess': '§aReport with ID \'{reportId}\' has been cleared.',
     'command.clearreports.idNotFound': '§cReport with ID \'{reportId}\' not found.',
@@ -358,7 +348,6 @@ export const stringDB = {
     // Example: 'some.module.someMessage': 'This is a message for {placeholder}.',
 
     // --- copyinv.js ---
-    'command.copyinv.usage': '§cUsage: {prefix}copyinv <playername>',
     'command.copyinv.playerNotFound': '§cPlayer \'{playerName}\' not found.',
     'command.copyinv.cannotSelf': '§cYou cannot copy your own inventory.',
     'command.copyinv.noAccess': '§cCould not access inventories.',
@@ -372,7 +361,6 @@ export const stringDB = {
     'command.copyinv.error.generic': '§cAn unexpected error occurred: {errorMessage}',
 
     // --- endlock.js ---
-    'command.endlock.usage': '§cUsage: {prefix}endlock <on|off|status>',
     'command.endlock.locked': '§aThe End dimension is now locked.',
     'command.endlock.unlocked': '§aThe End dimension is now unlocked.',
     'command.endlock.failUpdate': '§cFailed to update End lock status.',
@@ -382,7 +370,6 @@ export const stringDB = {
     'command.endlock.error.generic': '§cAn unexpected error occurred with the {commandName} command: {errorMessage}',
 
     // --- freeze.js ---
-    'command.freeze.usage': '§cUsage: {prefix}freeze <playername> [on|off|toggle|status]',
     // playerNotFound is common, can reuse 'common.error.playerNotFound'
     'command.freeze.cannotSelf': '§cYou cannot freeze yourself.',
     'command.freeze.status.isFrozen': '§ePlayer {playerName} is currently frozen.',
@@ -398,10 +385,7 @@ export const stringDB = {
     'command.freeze.alreadyUnfrozen': '§ePlayer {playerName} is already unfrozen.',
 
     // --- gma.js, gmc.js, gms.js, gmsp.js ---
-    'command.gamemode.gma.usage': '§cUsage: {prefix}gma [playername]',
-    'command.gamemode.gmc.usage': '§cUsage: {prefix}gmc [playername]',
-    'command.gamemode.gms.usage': '§cUsage: {prefix}gms [playername]',
-    'command.gamemode.gmsp.usage': '§cUsage: {prefix}gmsp [playername]',
+    // Usage strings for gamemode commands are not used/needed as they default to self if no args.
     'command.gamemode.success.other': '§aSet {playerName}\'s gamemode to {gamemodeName}.',
     'command.gamemode.success.self': '§aYour gamemode has been set to {gamemodeName}.',
     'command.gamemode.targetNotification': '§eYour gamemode has been set to {gamemodeName}.',
@@ -424,7 +408,6 @@ export const stringDB = {
     'command.help.noCommandsAvailable': '§7No commands available to you at this time.',
 
     // --- inspect.js ---
-    'command.inspect.usage': '§cUsage: {prefix}inspect <playername>',
     'command.inspect.header': '§6--- AntiCheat Status for {playerName} ---',
     'command.inspect.playerId': '§ePlayer ID: §f{playerId}',
     'command.inspect.watched': '§eWatched: §f{isWatched}',
@@ -440,7 +423,6 @@ export const stringDB = {
     'command.inspect.noData': '§cNo AntiCheat data found for this player.',
 
     // --- invsee.js ---
-    'command.invsee.usage': '§cUsage: {prefix}invsee <playername>',
     'command.invsee.noAccess': '§cCould not access {playerName}\'s inventory.',
     'ui.invsee.title': 'Inventory: {playerName}',
     'ui.invsee.header': '§6Inventory of {playerName}:§r',
@@ -454,7 +436,6 @@ export const stringDB = {
     'command.invsee.item.enchants': ' (Enchants: {enchantEntries})', // {enchantEntries} will be pre-joined
 
     // --- kick.js ---
-    'command.kick.usage': '§cUsage: {prefix}kick <playername> [reason]',
     'command.kick.cannotSelf': '§cYou cannot kick yourself.',
     'command.kick.noPermission': '§cYou do not have permission to kick this player.',
     'command.kick.noPermissionOwner': '§cOnly the server owner can kick another owner.',
@@ -486,7 +467,6 @@ export const stringDB = {
     'command.listwatched.header': 'Currently watched players: ',
 
     // --- mute.js ---
-    'command.mute.usage': '§cUsage: {prefix}mute <playername> [duration] [reason]',
     'command.mute.systemNoArgs': '[MuteCommand] Mute command called by system without sufficient arguments.',
     'command.mute.systemNoTarget': '[MuteCommand] System call missing target player name.',
     'command.mute.playerNotFound': '§cPlayer \'{playerName}\' not found.', // Reusable

--- a/Dev/tasks/completed.md
+++ b/Dev/tasks/completed.md
@@ -3,3 +3,11 @@
 This document lists significant tasks that have been completed.
 
 ---
+- **(High) Linting: Fix syntax errors and improve linting configuration.** (Jules)
+    - Ran ESLint, confirmed no initial errors with existing config.
+    - Reviewed ESLint configuration against coding guidelines.
+    - Improved ESLint configuration structure for clarity and to correctly apply rules to build scripts.
+    - Ensured Node.js globals are defined for build scripts, resolving `no-undef` errors.
+    - Added missing JSDoc `@file` overview to the build script.
+    - Confirmed all scripts now pass the updated linting rules.
+---

--- a/Dev/tasks/ongoing.md
+++ b/Dev/tasks/ongoing.md
@@ -2,10 +2,7 @@
 
 This document lists tasks currently being worked on. When a task is completed, it should be moved to `Dev/tasks/completed.md`. If a task is paused or deferred, it should be moved back to `Dev/tasks/todo.md`.
 
-- **(High) Linting: Fix syntax errors and improve linting configuration.** (Jules)
-    - Ran ESLint, confirmed no initial errors with existing config.
-    - Reviewed ESLint configuration against coding guidelines.
-    - Improved ESLint configuration structure for clarity and to correctly apply rules to build scripts.
-    - Ensured Node.js globals are defined for build scripts, resolving `no-undef` errors.
-    - Added missing JSDoc `@file` overview to the build script.
-    - Confirmed all scripts now pass the updated linting rules.
+- **(Low) Refactor `textDatabase.js` Content**: (Jules)
+    - Review existing strings in `stringDB` against new usage guidelines (see `Dev/StandardizationGuidelines.md`).
+    - Identify single-use, static strings that could be moved to their respective local modules.
+    - Implement refactoring for identified strings to improve `textDatabase.js` focus and maintainability.

--- a/Dev/tasks/todo.md
+++ b/Dev/tasks/todo.md
@@ -15,7 +15,4 @@ This list contains planned features, improvements, and areas for future investig
 ## General Code & System Improvements (Suggestions by Jules)
 
 ### Configuration Files & Data Structures
-- **(Low) Refactor `textDatabase.js` Content**:
-    - Review existing strings in `stringDB` against new usage guidelines (see `Dev/StandardizationGuidelines.md`).
-    - Identify single-use, static strings that could be moved to their respective local modules.
-    - Implement refactoring for identified strings to improve `textDatabase.js` focus and maintainability.
+<!-- Placeholder for future tasks -->


### PR DESCRIPTION
Moved command-specific description and usage strings from `textDatabase.js` to their respective command definition files or as local constants within the command's `execute` function.

Changes made:

- Updated command definition files (`tpa.js`, `tpacancel.js`, `tpaccept.js`, `tpahere.js`, `tpastatus.js`, `unban.js`, `unmute.js`) to include their descriptions directly.
- Removed corresponding description entries from `textDatabase.js`.
- Updated command files (`addrank.js`, `ban.js`, `clearreports.js`, `copyinv.js`, `endlock.js`, `freeze.js`, `inspect.js`, `invsee.js`, `kick.js`, `mute.js`, `netherlock.js`, `notify.js`, `purgeflags.js`) to use local constants for their usage messages.
- Removed corresponding usage message entries from `textDatabase.js`.

This is part of the larger effort to refactor `textDatabase.js` for improved maintainability by localizing single-use strings, as outlined in the standardization guidelines.