### PR TITLE
Refactor(commands): Improve reason handling in kick command

### DIFF
--- a/AntiCheatsBP/scripts/modules/commands/kick.js
+++ b/AntiCheatsBP/scripts/modules/commands/kick.js
@@ -31,11 +31,16 @@ export function execute(
     const targetPlayerName = args[0];
     let reason;
 
-    if (invokedBy === 'AutoMod' && programmaticReason) {
+    // Prioritize a directly provided programmatic reason for any non-player invocation.
+    if (programmaticReason && invokedBy !== 'PlayerCommand') {
         reason = programmaticReason;
-    } else if (invokedBy === 'AutoMod') {
+    }
+    // If it's an automod action without a specific programmatic reason, generate a default one.
+    else if (invokedBy === 'AutoMod') {
         reason = getString('command.kick.automodReason', { checkType: autoModCheckType || 'violations' });
-    } else {
+    }
+    // For player commands (or as a fallback), parse the reason from arguments.
+    else {
         const parsedArgsUtil = playerUtils.parsePlayerAndReasonArgs(args, 1, 'common.value.noReasonProvided', dependencies);
         reason = parsedArgsUtil.reason;
     }


### PR DESCRIPTION
The `execute` function in `kick.js` had logic for determining the kick reason that was too specific to the `AutoMod` caller. This limited the reusability of the function for other internal systems that might need to programmatically kick a player with a specific reason.

This change refactors the reason-handling logic to be more generic. It now prioritizes any `programmaticReason` supplied to the function for any non-`PlayerCommand` invocation. This makes the function more robust, predictable, and easier to reuse for future internal modules, improving the overall modularity of the codebase.

---
name: Pull Request
about: Propose changes to the AntiCheats Addon
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Thank you for your contribution!**

**Please provide a clear description of the changes you're proposing.**

**Type of Change:**
<!-- Please check the relevant option(s) by putting an `x` in the box: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

**Related Issue(s):**
<!-- Link to any related issues here, e.g., "Fixes #123", "Closes #456". -->
<!-- If this PR is not related to any specific issue, please state that or explain the motivation. -->

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Include details of your testing environment if relevant.
Examples:
- Tested in-game on Minecraft Bedrock version X.Y.Z.
- Steps taken:
  1. Loaded world with addon.
  2. Executed command `!somecommand` with specific parameters.
  3. Observed outcome A, B, C.
- Verified that X check no longer false positives under Y conditions.
- Confirmed new feature Z works as expected.
-->

**Checklist:**
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING.md**](https://github.com/SjnExe/AntiCheats/blob/main/.github/CONTRIBUTING.md) document.
- [ ] My code follows the [**Coding Style Guide**](https://github.com/SjnExe/AntiCheats/blob/main/Dev/CodingStyle.md) and [**Standardization Guidelines**](https://github.com/SjnExe/AntiCheats/blob/main/Dev/StandardizationGuidelines.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas, and added/updated JSDoc comments where necessary.
- [ ] I have made corresponding changes to the documentation (in the `Docs/` folder) if my changes are user-facing or modify existing features.
- [ ] My changes do not generate new ESLint warnings or errors (run `npm run lint` locally).
- [ ] I have tested my changes thoroughly and they do not introduce new bugs or break existing functionality.
- [ ] Any new and/or changed configurable options have been added to `config.js` with clear comments and default values.

**Screenshots or Videos (Optional but Recommended):**
<!-- If your changes include UI modifications or visual behavior changes, please provide screenshots or a short video. -->

**Additional Context (Optional):**
<!-- Add any other context about the PR here. -->

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AntiCheats/blob/main/LICENSE).
