### PR TITLE
fix(playerdata): Correct fallDistance reset logic

### DIFF
--- a/AntiCheatsBP/scripts/core/playerDataManager.js
+++ b/AntiCheatsBP/scripts/core/playerDataManager.js
@@ -531,12 +531,6 @@ export function updateTransientPlayerData(player, pData, dependencies) {
     transient.isSleeping = player.isSleeping;
     transient.isInsideWater = player.isInWater;
 
-    // If player was on ground last tick and is still on ground, reset fall distance.
-    // This ensures fallDistance is cleared at the start of the tick's processing.
-    if (onGround && (pData.consecutiveOffGroundTicks || 0) === 0) {
-        pData.fallDistance = 0;
-    }
-
     if (!onGround) {
         // Player is in the air
         pData.consecutiveOffGroundTicks = (pData.consecutiveOffGroundTicks || 0) + 1;
@@ -545,8 +539,9 @@ export function updateTransientPlayerData(player, pData, dependencies) {
             pData.fallDistance = (pData.fallDistance || 0) - velocity.y;
         }
     } else {
-        // Player is on the ground now. Reset the off-ground counter.
-        // The final fallDistance from the flight is preserved for this tick because the reset logic above did not run.
+        // Player is on the ground now.
+        // The final fallDistance from the flight is preserved for this tick's checks, then reset.
+        pData.fallDistance = 0;
         pData.consecutiveOffGroundTicks = 0;
         transient.ticksSinceLastOnGround = 0;
         pData.lastOnGroundPosition = { ...player.location };


### PR DESCRIPTION
The `fallDistance` property in the player's transient data was previously being reset one tick *after* the player landed on the ground. This was due to the reset condition checking if the player was on the ground for two consecutive ticks.

This change moves the `fallDistance = 0;` assignment into the `else` block that executes when `isOnGround` first becomes true. This ensures the fall distance from a flight is available for any checks on the landing tick, and is then immediately and correctly cleared for the next tick, preventing potential double-counting or other logical errors in dependent systems like fall damage detection.

---
name: Pull Request
about: Propose changes to the AntiCheats Addon
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Thank you for your contribution!**

**Please provide a clear description of the changes you're proposing.**

**Type of Change:**
<!-- Please check the relevant option(s) by putting an `x` in the box: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

**Related Issue(s):**
<!-- Link to any related issues here, e.g., "Fixes #123", "Closes #456". -->
<!-- If this PR is not related to any specific issue, please state that or explain the motivation. -->

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Include details of your testing environment if relevant.
Examples:
- Tested in-game on Minecraft Bedrock version X.Y.Z.
- Steps taken:
  1. Loaded world with addon.
  2. Executed command `!somecommand` with specific parameters.
  3. Observed outcome A, B, C.
- Verified that X check no longer false positives under Y conditions.
- Confirmed new feature Z works as expected.
-->

**Checklist:**
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING.md**](https://github.com/SjnExe/AntiCheats/blob/main/.github/CONTRIBUTING.md) document.
- [ ] My code follows the [**Coding Style Guide**](https://github.com/SjnExe/AntiCheats/blob/main/Dev/CodingStyle.md) and [**Standardization Guidelines**](https://github.com/SjnExe/AntiCheats/blob/main/Dev/StandardizationGuidelines.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas, and added/updated JSDoc comments where necessary.
- [ ] I have made corresponding changes to the documentation (in the `Docs/` folder) if my changes are user-facing or modify existing features.
- [ ] My changes do not generate new ESLint warnings or errors (run `npm run lint` locally).
- [ ] I have tested my changes thoroughly and they do not introduce new bugs or break existing functionality.
- [ ] Any new and/or changed configurable options have been added to `config.js` with clear comments and default values.

**Screenshots or Videos (Optional but Recommended):**
<!-- If your changes include UI modifications or visual behavior changes, please provide screenshots or a short video. -->

**Additional Context (Optional):**
<!-- Add any other context about the PR here. -->

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AntiCheats/blob/main/LICENSE).
