### PR TITLE
refactor(config): Implement strict validation for unknown keys

### DIFF
--- a/AntiCheatsBP/scripts/core/configValidator.js
+++ b/AntiCheatsBP/scripts/core/configValidator.js
@@ -143,6 +143,14 @@ function ensureFields(obj, fieldDefs, context, errors) {
             }
         }
     }
+    const knownKeys = new Set(fieldDefs.map(f => f.name));
+    for (const key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+            if (!knownKeys.has(key)) {
+                errors.push(`${context}.${key}: Unknown key "${key}" found. It will be ignored.`);
+            }
+        }
+    }
     return allFieldsValid;
 }
 /**
@@ -371,16 +379,6 @@ export function validateMainConfig(config, actionProfiles, knownCommands, comman
         { name: 'checks', type: 'object' }, // Further validation could be added for each check
     ];
     ensureFields(config, configFieldDefs, context, errors);
-    const knownKeys = configFieldDefs.map(f => f.name);
-    const manuallyHandledKeys = ['soundEvents', 'commandSettings'];
-    for (const key in config) {
-        if (!Object.prototype.hasOwnProperty.call(config, key)) {
-            continue;
-        }
-        if (!knownKeys.includes(key) && !manuallyHandledKeys.includes(key)) {
-            errors.push(`${context}.${key}: Unknown key "${key}" found in config. It will be ignored.`);
-        }
-    }
     if (commandAliasesMap) {
         if (isObject(commandAliasesMap)) {
             const aliasContext = 'config.commandAliases';


### PR DESCRIPTION
The configuration validator was silently ignoring unknown or misspelled keys within nested configuration objects. This could lead to user confusion and difficult-to-debug issues when a configuration option didn't seem to work due to a typo.

This change enhances the `ensureFields` utility function to check for any keys present in a configuration object that are not defined in its schema. This ensures that all parts of the configuration are strictly validated.

- Modified `ensureFields` to detect and report unknown properties.
- Removed the redundant, top-level-only unknown key check from `validateMainConfig` to centralize the logic in `ensureFields`.

---
name: Pull Request
about: Propose changes to the AntiCheats Addon
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Thank you for your contribution!**

**Please provide a clear description of the changes you're proposing.**

**Type of Change:**
<!-- Please check the relevant option(s) by putting an `x` in the box: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

**Related Issue(s):**
<!-- Link to any related issues here, e.g., "Fixes #123", "Closes #456". -->
<!-- If this PR is not related to any specific issue, please state that or explain the motivation. -->

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Include details of your testing environment if relevant.
Examples:
- Tested in-game on Minecraft Bedrock version X.Y.Z.
- Steps taken:
  1. Loaded world with addon.
  2. Executed command `!somecommand` with specific parameters.
  3. Observed outcome A, B, C.
- Verified that X check no longer false positives under Y conditions.
- Confirmed new feature Z works as expected.
-->

**Checklist:**
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING.md**](https://github.com/SjnExe/AntiCheats/blob/main/.github/CONTRIBUTING.md) document.
- [ ] My code follows the [**Coding Style Guide**](https://github.com/SjnExe/AntiCheats/blob/main/Dev/CodingStyle.md) and [**Standardization Guidelines**](https://github.com/SjnExe/AntiCheats/blob/main/Dev/StandardizationGuidelines.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas, and added/updated JSDoc comments where necessary.
- [ ] I have made corresponding changes to the documentation (in the `Docs/` folder) if my changes are user-facing or modify existing features.
- [ ] My changes do not generate new ESLint warnings or errors (run `npm run lint` locally).
- [ ] I have tested my changes thoroughly and they do not introduce new bugs or break existing functionality.
- [ ] Any new and/or changed configurable options have been added to `config.js` with clear comments and default values.

**Screenshots or Videos (Optional but Recommended):**
<!-- If your changes include UI modifications or visual behavior changes, please provide screenshots or a short video. -->

**Additional Context (Optional):**
<!-- Add any other context about the PR here. -->

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AntiCheats/blob/main/LICENSE).
