### PR TITLE
refactor(playerDataManager): Remove unused 'reason' parameter from ad…

### DIFF
--- a/AntiCheatsBP/scripts/core/actionManager.js
+++ b/AntiCheatsBP/scripts/core/actionManager.js
@@ -94,7 +94,7 @@ async function _handleFlagging(player, profile, flagReasonMessage, checkType, de
     const flagType = profile.flag.type || checkType;
     const increment = typeof profile.flag.increment === 'number' ? profile.flag.increment : 1;
 
-    await dependencies.playerDataManager?.addFlag(player, flagType, flagReasonMessage, dependencies, violationDetails, increment);
+    await dependencies.playerDataManager?.addFlag(player, flagType, dependencies, violationDetails, increment);
 
     dependencies.playerUtils?.debugLog(`[ActionManager] Dispatched flag action for ${player.nameTag} for ${flagType} (x${increment}). Reason: '${flagReasonMessage}'`, player.nameTag, dependencies);
 }

--- a/AntiCheatsBP/scripts/core/playerDataManager.js
+++ b/AntiCheatsBP/scripts/core/playerDataManager.js
@@ -686,13 +686,12 @@ export function removePlayerStateRestriction(pData, stateType, dependencies) {
  * Adds a flag or multiple flags to a player's data and triggers the automod check.
  * @param {import('@minecraft/server').Player} player The player object.
  * @param {string} flagType The type of flag to add (e.g., 'movementFlyHover').
- * @param {string} reason A descriptive reason for the flag.
  * @param {import('../types.js').Dependencies} dependencies The dependencies object.
  * @param {import('../types.js').ViolationDetails} [violationDetails] Specific details about the violation.
  * @param {number} [amount=1] The number of flags of this type to add.
  * @returns {Promise<void>}
  */
-export async function addFlag(player, flagType, reason, dependencies, violationDetails, amount = 1) {
+export async function addFlag(player, flagType, dependencies, violationDetails, amount = 1) {
     if (amount <= 0) return;
 
     const { playerDataManager, automodManager, playerUtils } = dependencies;


### PR DESCRIPTION
…dFlag

The `addFlag` function in `playerDataManager.js` had a `reason` parameter that was documented but not used within the function body. This created a discrepancy between the function's API contract and its implementation, potentially causing confusion for developers.

This change removes the unused `reason` parameter from the function signature and its corresponding JSDoc comment. The call site in `actionManager.js` has also been updated to match the new signature. This improves code clarity and maintainability by ensuring the function's definition accurately reflects its behavior.

---
name: Pull Request
about: Propose changes to the AntiCheats Addon
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Thank you for your contribution!**

**Please provide a clear description of the changes you're proposing.**

**Type of Change:**
<!-- Please check the relevant option(s) by putting an `x` in the box: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

**Related Issue(s):**
<!-- Link to any related issues here, e.g., "Fixes #123", "Closes #456". -->
<!-- If this PR is not related to any specific issue, please state that or explain the motivation. -->

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Include details of your testing environment if relevant.
Examples:
- Tested in-game on Minecraft Bedrock version X.Y.Z.
- Steps taken:
  1. Loaded world with addon.
  2. Executed command `!somecommand` with specific parameters.
  3. Observed outcome A, B, C.
- Verified that X check no longer false positives under Y conditions.
- Confirmed new feature Z works as expected.
-->

**Checklist:**
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING.md**](https://github.com/SjnExe/AntiCheats/blob/main/.github/CONTRIBUTING.md) document.
- [ ] My code follows the [**Coding Style Guide**](https://github.com/SjnExe/AntiCheats/blob/main/Dev/CodingStyle.md) and [**Standardization Guidelines**](https://github.com/SjnExe/AntiCheats/blob/main/Dev/StandardizationGuidelines.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas, and added/updated JSDoc comments where necessary.
- [ ] I have made corresponding changes to the documentation (in the `Docs/` folder) if my changes are user-facing or modify existing features.
- [ ] My changes do not generate new ESLint warnings or errors (run `npm run lint` locally).
- [ ] I have tested my changes thoroughly and they do not introduce new bugs or break existing functionality.
- [ ] Any new and/or changed configurable options have been added to `config.js` with clear comments and default values.

**Screenshots or Videos (Optional but Recommended):**
<!-- If your changes include UI modifications or visual behavior changes, please provide screenshots or a short video. -->

**Additional Context (Optional):**
<!-- Add any other context about the PR here. -->

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AntiCheats/blob/main/LICENSE).
