### PR TITLE
Fix(Config): Prevent type corruption for null-defaulted keys

### DIFF
--- a/AntiCheatsBP/scripts/config.js
+++ b/AntiCheatsBP/scripts/config.js
@@ -476,13 +476,19 @@ export function updateConfigValue(key, value) {
             if (!Array.isArray(coercedValue)) {
                 throw new Error(`expected an array or its JSON string representation, but got type ${typeof value}`);
             }
-        } else if (typeof currentDefault[finalKey] === 'object' && currentDefault[finalKey] !== null) {
-            // If the input is a string, assume it's JSON. Otherwise, it must already be an object.
+        } else if (typeof currentDefault[finalKey] === 'object') { // This condition now correctly includes null defaults
+            // If the input is a string, assume it's JSON. Otherwise, it must already be an object or null.
             if (typeof value === 'string') {
-                coercedValue = JSON.parse(value);
+                // Allow empty string or 'null' to represent the null value
+                if (value.trim() === '' || value.toLowerCase() === 'null') {
+                    coercedValue = null;
+                } else {
+                    coercedValue = JSON.parse(value);
+                }
             }
-            if (typeof coercedValue !== 'object' || coercedValue === null || Array.isArray(coercedValue)) {
-                throw new Error(`expected an object or its JSON string representation, but got type ${typeof value}`);
+            // A valid value can be null or a non-array object.
+            if (coercedValue !== null && (typeof coercedValue !== 'object' || Array.isArray(coercedValue))) {
+                throw new Error(`expected an object, its JSON string representation, or null, but got type ${typeof coercedValue}`);
             }
         }
     } catch (e) {

--- a/AntiCheatsBP/scripts/core/playerDataManager.js
+++ b/AntiCheatsBP/scripts/core/playerDataManager.js
@@ -567,7 +567,7 @@ export function updateTransientPlayerData(player, pData, dependencies) {
     const distanceMoved = Math.sqrt(
         ((currentLocation.x - previousLocation.x) ** 2) +
         ((currentLocation.y - previousLocation.y) ** 2) +
-        ((currentLocation.z - previousLocation.z) ** 2)
+        ((currentLocation.z - previousLocation.z) ** 2),
     );
 
     const teleportThreshold = config?.development?.teleportDistanceThreshold ?? 10;
@@ -590,7 +590,6 @@ export function updateTransientPlayerData(player, pData, dependencies) {
         transient.fallDistance = 0;
     }
 
-    const currentLocation = player.location;
     pData.lastKnownLocation.x = currentLocation.x;
     pData.lastKnownLocation.y = currentLocation.y;
     pData.lastKnownLocation.z = currentLocation.z;

--- a/AntiCheatsBP/scripts/modules/detections/movement/flyCheck.js
+++ b/AntiCheatsBP/scripts/modules/detections/movement/flyCheck.js
@@ -151,7 +151,6 @@ export async function checkFly(player, pData, dependencies) {
     const hoverVSpeedThreshold = config?.flyHoverVerticalSpeedThreshold ?? 0.08;
     let hoverOffGroundTicks = config?.flyHoverOffGroundTicksThreshold ?? 20;
     let hoverMaxFallDist = config?.flyHoverMaxFallDistanceThreshold ?? 1.0;
-    const hoverMinHeight = config?.flyHoverNearGroundThreshold ?? 2.5;
 
     if (pData.hasSlowFalling) {
         hoverMaxFallDist *= 1.5;


### PR DESCRIPTION
The `updateConfigValue` function in `config.js` did not correctly handle configuration keys that have a default value of `null`. The logic for parsing object types explicitly excluded these keys, causing the function to assign the raw, unparsed string value, leading to type corruption at runtime.

This change corrects the conditional logic to properly handle these keys, ensuring that JSON strings are parsed into objects and that `null` is treated as a valid value.

Additionally, this commit resolves several pre-existing linting errors that were discovered while verifying the change:
- Fixed a duplicate variable declaration in `playerDataManager.js`.
- Removed an unused variable in `flyCheck.js`.
- Corrected a missing trailing comma style issue.

---
name: Pull Request
about: Propose changes to the AntiCheats Addon
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
Link to any related issues here, e.g., "Fixes #123".
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

**Checklist:**
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] My changes do not generate new ESLint warnings or errors.
- [ ] I have tested my changes thoroughly.

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AntiCheats/blob/main/LICENSE).
