### PR TITLE
feat(lint): Restrict linting to AntiCheats directories

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,13 @@ export default [
             'package-lock.json',
             '.git/',
             'AntiCheatsRP/font/',
+            '.github/',
+            'Dev/',
+            'Docs/',
+            'OldAntiCheatsBP/',
+            'OldAntiCheatsRP/',
+            'eslint.config.js',
+            'package.json',
         ],
     },
     // Base JS configuration


### PR DESCRIPTION
Modified the ESLint configuration to only lint the `AntiCheatsRP` and `AntiCheatsBP` directories. This was achieved by adding all other project directories and configuration files to the `ignores` list in `eslint.config.js`.

This change ensures that the linting process is focused on the relevant source code and avoids checking files that are not part of the addon's behavior or resource packs.

---
name: Pull Request
about: Propose changes to the AntiCheats Addon
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
Link to any related issues here, e.g., "Fixes #123".
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

**Checklist:**
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] My changes do not generate new ESLint warnings or errors.
- [ ] I have tested my changes thoroughly.

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AntiCheats/blob/main/LICENSE).
